### PR TITLE
Add frontmatter structure controls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PREFIX ?= /usr/local
 BIN_DIR := $(PREFIX)/bin
 SRC_BIN := $(shell pwd)/bin/md2pdf
 
-.PHONY: install install-link uninstall test check-deps help
+.PHONY: install install-link uninstall test check-deps install-prereqs help
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-15s %s\n", $$1, $$2}'
@@ -23,8 +23,21 @@ uninstall: ## Remove md2pdf from PREFIX/bin
 	@echo "Removed: $(BIN_DIR)/md2pdf"
 
 test: ## Run test suite (requires bats-core)
-	@command -v bats >/dev/null 2>&1 || { echo "bats-core is required: brew install bats-core"; exit 1; }
+	@command -v bats >/dev/null 2>&1 || { echo "bats-core is required: run 'make install-prereqs' or 'brew install bats-core'"; exit 1; }
 	bats tests/
 
 check-deps: ## Check dependencies for all modes
 	./bin/md2pdf --check-deps-all
+
+install-prereqs: ## Install development prerequisites (bats-core)
+	@if command -v bats >/dev/null 2>&1; then \
+		echo "bats-core already installed: $$(bats --version)"; \
+	elif command -v brew >/dev/null 2>&1; then \
+		brew install bats-core; \
+	elif command -v apt-get >/dev/null 2>&1; then \
+		sudo apt-get update && sudo apt-get install -y bats; \
+	else \
+		echo "Cannot auto-install bats-core on this platform."; \
+		echo "See https://bats-core.readthedocs.io/en/stable/installation.html"; \
+		exit 1; \
+	fi

--- a/README.md
+++ b/README.md
@@ -83,7 +83,11 @@ Common options:
   -s SIZE             Font size (default: 11pt)
   --page-numbers      Show page numbers where supported (default: on)
   --no-page-numbers   Hide page numbers where supported
+  --toc               Generate table of contents where supported
   --no-toc            Omit table of contents where supported
+  --number-sections   Number section headings
+  --no-number-sections
+                      Do not number section headings
 
 Actions:
   --list-modes        List modes and install status
@@ -109,12 +113,28 @@ md2pdf --mode pandoc-lualatex README.md
 # Custom title, author, and formatting
 md2pdf -t "My Report" -a "Jane Doe" -m "0.5in" -s "12pt" report.md
 
+# Override frontmatter-controlled generated structure
+md2pdf --toc --no-number-sections report.md
+
 # List all modes and their install status
 md2pdf --list-modes
 
 # Check if dependencies are met
 md2pdf --mode go-md2pdf --check-deps
 ```
+
+Pandoc modes also honor YAML frontmatter for table-of-contents and section
+numbering control:
+
+```yaml
+---
+toc: false
+numbersections: false
+---
+```
+
+`number_sections:` is accepted by `md2pdf` and normalized to pandoc's
+`numbersections:` metadata key before rendering.
 
 ## Configuration
 

--- a/bin/md2pdf
+++ b/bin/md2pdf
@@ -90,6 +90,65 @@ module RenderHelpers
     File.write(path, content)
     path
   end
+
+  def number_sections?(content)
+    !frontmatter_controls_numbering?(content) && !numbered_h2?(content)
+  end
+
+  def resolve_number_sections(content, override)
+    return override unless override.nil?
+
+    number_sections?(content)
+  end
+
+  def resolve_toc(content, override, default)
+    return override unless override.nil?
+
+    frontmatter_bool(content, "toc") { default }
+  end
+
+  def normalize_number_sections_frontmatter(content)
+    content.sub(/\A((?:\uFEFF)?---[ \t]*\r?\n.*?\r?\n---[ \t]*(?:\r?\n|\z))/m) do |frontmatter|
+      frontmatter.gsub(/^([ \t]*)number_sections([ \t]*:)/, "\\1numbersections\\2")
+    end
+  end
+
+  def frontmatter_bool(content, key)
+    body = frontmatter_body(content)
+    return yield unless body
+
+    body.each_line do |line|
+      next unless (match = line.match(/^[ \t]*#{Regexp.escape(key)}[ \t]*:[ \t]*(?<value>[^#\r\n]*)/))
+
+      value = match[:value].strip.downcase
+      return true if %w[true yes on 1].include?(value)
+      return false if %w[false no off 0].include?(value)
+    end
+
+    yield
+  end
+
+  def frontmatter_controls_numbering?(content)
+    body = frontmatter_body(content)
+    return false unless body
+
+    body.each_line.any? { |line| line.match?(/^[ \t]*(numbersections|number_section|number_sections)[ \t]*:/) }
+  end
+
+  def frontmatter_body(content)
+    content.match(/\A(?:\uFEFF)?---[ \t]*\r?\n(?<body>.*?)\r?\n---[ \t]*(?:\r?\n|\z)/m)&.[](:body)
+  end
+
+  def numbered_h2?(content)
+    in_fence = false
+
+    content.each_line.any? do |line|
+      in_fence = !in_fence if line.match?(/^[ \t]*(```|~~~)/)
+      next false if in_fence
+
+      line.match?(/^[ \t]*##(?!#)[ \t]+\d/) || line.match?(/^[ \t]*<h2(?:[ \t][^>]*)?>[ \t]*\d/i)
+    end
+  end
 end
 
 # --- Pandoc render builder ---
@@ -100,13 +159,18 @@ PANDOC_RENDER = ->(ctx) do
 
   # Preprocess: title block + unicode normalization
   content = "% #{ctx[:title]}\n% #{ctx[:author] || ""}\n% #{ctx[:date]}\n\n"
-  content << File.read(ctx[:input], encoding: "utf-8")
+  content << RenderHelpers.normalize_number_sections_frontmatter(File.read(ctx[:input], encoding: "utf-8"))
   LATEX_UNICODE.each { |k, v| content.gsub!(k, v) }
   PDFLATEX_EXTRA.each { |k, v| content.gsub!(k, v) } if engine == "pdflatex"
   tmp_md = RenderHelpers.tmpfile(ctx, "combined.md", content)
 
-  cmd = %W[pandoc #{tmp_md} --number-sections --resource-path=#{ctx[:resource_path]}
+  cmd = %W[pandoc #{tmp_md} --resource-path=#{ctx[:resource_path]}
            --pdf-engine=#{engine} -V linkcolor:blue -V urlcolor:blue -o #{ctx[:output]}]
+  cmd << "--number-sections" if ctx[:number_sections]
+  cmd << "--metadata=numbersections:true" if ctx[:number_sections_override] == true
+  cmd << "--metadata=numbersections:false" if ctx[:number_sections_override] == false
+  cmd << "--metadata=toc:true" if ctx[:toc_override] == true
+  cmd << "--metadata=toc:false" if ctx[:toc_override] == false
 
   case engine
   when "xelatex", "lualatex"
@@ -318,7 +382,8 @@ class Md2Pdf
     @font_family = DEFAULTS[:font_family]
     @margin = DEFAULTS[:margin]
     @fontsize = DEFAULTS[:fontsize]
-    @toc = DEFAULTS[:toc]
+    @toc = nil
+    @number_sections = nil
     @page_numbers = DEFAULTS[:page_numbers]
     @font_explicit = false
     @title = nil
@@ -356,7 +421,8 @@ class Md2Pdf
       opts.on("--font FONT", "Body font") { |v| @font_family = v; @font_explicit = true }
       opts.on("-m MARGIN", "Page margin (default: #{DEFAULTS[:margin]})") { |v| @margin = v }
       opts.on("-s SIZE", "Font size (default: #{DEFAULTS[:fontsize]})") { |v| @fontsize = v }
-      opts.on("--[no-]toc", "Table of contents (default: on)") { |v| @toc = v }
+      opts.on("--[no-]toc", "Table of contents (default: on unless frontmatter sets toc)") { |v| @toc = v }
+      opts.on("--[no-]number-sections", "Number section headings (default: on unless frontmatter or numbered H2 controls it)") { |v| @number_sections = v }
       opts.on("--[no-]page-numbers", "Page numbers (default: on)") { |v| @page_numbers = v }
       opts.on("--list-modes", "List modes and install status") { @action = :list_modes }
       opts.on("--check-deps", "Check deps for selected mode") { @action = :check_deps }
@@ -433,13 +499,18 @@ class Md2Pdf
     resolved = resolve_output
     FileUtils.mkdir_p(File.dirname(resolved))
     tmpdir = new_temp_dir
+    source_content = File.read(@input_file, encoding: "utf-8")
 
     ctx = {
       binary: binary, input: @input_file, output: resolved, tmpdir: tmpdir,
       title: detect_title, author: @author, date: latex_date,
       margin: @margin, fontsize: @fontsize, font: @font_family,
-      toc: @toc, page_numbers: @page_numbers,
+      toc: RenderHelpers.resolve_toc(source_content, @toc, DEFAULTS[:toc]),
+      toc_override: @toc,
+      page_numbers: @page_numbers,
       engine: cfg[:engine],
+      number_sections: RenderHelpers.resolve_number_sections(source_content, @number_sections),
+      number_sections_override: @number_sections,
       resource_path: "#{File.dirname(File.expand_path(@input_file))}:.:#{@script_dir}",
     }
 
@@ -511,7 +582,7 @@ class Md2Pdf
     @warnings << "mode #{@mode} ignores -m/--margin" if @margin != DEFAULTS[:margin] && !supports.include?(:margin)
     @warnings << "mode #{@mode} ignores -s/--size" if @fontsize != DEFAULTS[:fontsize] && !supports.include?(:fontsize)
     @warnings << "mode #{@mode} does not support arbitrary system font selection" if @font_explicit && !supports.include?(:font)
-    @warnings << "mode #{@mode} does not support auto-generated TOC" if @toc != DEFAULTS[:toc] && !supports.include?(:toc)
+    @warnings << "mode #{@mode} does not support auto-generated TOC" if !@toc.nil? && @toc != DEFAULTS[:toc] && !supports.include?(:toc)
   end
 
   def flush_warnings

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,0 +1,52 @@
+- [x] Restate goal + acceptance criteria
+  - Goal: Do not add pandoc's automatic `--number-sections` flag when the source already signals section numbering.
+  - Acceptance: `--number-sections` is omitted when YAML frontmatter includes `numbersections`, `number_section`, or `number_sections`, or when an existing level-2 heading starts with a number; default behavior remains numbered.
+- [x] Locate existing implementation / patterns
+  - Pandoc arguments are built in `PANDOC_RENDER` in `bin/md2pdf`.
+  - CLI defaults live in `DEFAULTS` and are copied into render context in `Md2Pdf#render`.
+- [x] Design: minimal approach + key decisions
+  - Add a `number_sections` context value derived from source content before rendering.
+  - Omit hard-coded `--number-sections` when frontmatter or existing H2 numbering indicates numbering is already controlled by the document.
+- [x] Implement smallest safe slice
+- [x] Add/adjust tests
+- [x] Run verification (lint/tests/build/manual repro)
+- [x] Summarize changes + verification story
+- [x] Record lessons (if any)
+- [x] Add explicit section numbering and TOC override flags
+  - Acceptance: `--number-sections` and `--no-number-sections` explicitly set pandoc section numbering.
+  - Acceptance: `--toc` and `--no-toc` override frontmatter, while `toc: true/false` is honored when no CLI TOC flag is provided.
+  - Acceptance: `number_sections:` continues to normalize to pandoc's `numbersections:`.
+
+## Follow-up Results
+
+- Added `--[no-]number-sections`.
+- Changed TOC handling so frontmatter `toc: true/false` is honored unless `--toc` or `--no-toc` is supplied.
+- CLI overrides emit pandoc metadata (`numbersections:true/false`, `toc:true/false`) so they win over document frontmatter.
+- Verified pandoc's frontmatter key for TOC is `toc`; `toc-depth` controls depth.
+- Verification:
+  - `ruby -c bin/md2pdf` passed.
+  - `git diff --check` passed.
+  - `./bin/md2pdf --help` shows `--[no-]toc` and `--[no-]number-sections`.
+  - Manual fake-pandoc harness passed for default behavior, frontmatter detection, and CLI overrides.
+  - `make test` passed: 89 tests.
+
+## Working Notes
+
+- Keep this as source-content detection, not a new user-facing flag.
+- Use fake `pandoc` and TeX binaries in tests so argv can be asserted without external renderer dependencies.
+- Normalize `number_sections:` to pandoc's `numbersections:` metadata key in the temporary markdown passed to pandoc.
+
+## Results
+
+- Added source-content detection for `numbersections`, `number_section`, `number_sections`, numbered markdown H2 headings, and numbered HTML H2 tags.
+- Added frontmatter normalization so `number_sections:` is rewritten to `numbersections:` before pandoc runs.
+- Pandoc still defaults to `--number-sections` unless one of those document-level signals is present.
+- Added `tests/section_numbering.bats` with fake renderer assertions for the pandoc argv.
+- Verification:
+  - `ruby -c bin/md2pdf` passed.
+  - Direct `RenderHelpers.number_sections?` checks passed.
+  - Manual fake-pandoc CLI harness passed for default, all three frontmatter spellings, markdown H2, and HTML H2 cases.
+  - Manual pandoc metadata probe confirmed pandoc reads `numbersections` from the generated metadata position.
+  - `git diff --check` passed.
+  - `make test` could not run because `bats-core` is not installed.
+- Lessons: none; no correction or postmortem occurred.

--- a/tests/section_numbering.bats
+++ b/tests/section_numbering.bats
@@ -1,0 +1,173 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup_fake_pandoc() {
+  mkdir -p "$TEST_TEMP_DIR/fake-bin"
+
+  cat > "$TEST_TEMP_DIR/fake-bin/xelatex" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+
+  cat > "$TEST_TEMP_DIR/fake-bin/pandoc" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$MD2PDF_PANDOC_ARGS_LOG"
+cp "$1" "$MD2PDF_PANDOC_INPUT_LOG"
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-o" ]; then
+    shift
+    touch "$1"
+    exit 0
+  fi
+  shift
+done
+exit 0
+SH
+
+  chmod +x "$TEST_TEMP_DIR/fake-bin/pandoc" "$TEST_TEMP_DIR/fake-bin/xelatex"
+  export PATH="$TEST_TEMP_DIR/fake-bin:$PATH"
+  export MD2PDF_PANDOC_ARGS_LOG="$TEST_TEMP_DIR/pandoc-args.txt"
+  export MD2PDF_PANDOC_INPUT_LOG="$TEST_TEMP_DIR/pandoc-input.md"
+}
+
+write_doc() {
+  local path="$1"
+  shift
+  printf '%s\n' "$@" > "$path"
+}
+
+assert_arg_present() {
+  grep -qx -- "$1" "$MD2PDF_PANDOC_ARGS_LOG"
+}
+
+assert_arg_absent() {
+  ! grep -qx -- "$1" "$MD2PDF_PANDOC_ARGS_LOG"
+}
+
+@test "default pandoc render numbers sections" {
+  setup_fake_pandoc
+  local input="$TEST_TEMP_DIR/default.md"
+  write_doc "$input" "# Title" "" "## Introduction" "" "Body"
+
+  run "$MD2PDF" "$input" "$TEST_TEMP_DIR/out.pdf"
+
+  [ "$status" -eq 0 ]
+  assert_arg_present "--number-sections"
+}
+
+@test "frontmatter numbersections disables automatic section numbering" {
+  setup_fake_pandoc
+  local input="$TEST_TEMP_DIR/frontmatter-numbersections.md"
+  write_doc "$input" "---" "numbersections: true" "---" "" "# Title" "" "## Introduction"
+
+  run "$MD2PDF" "$input" "$TEST_TEMP_DIR/out.pdf"
+
+  [ "$status" -eq 0 ]
+  assert_arg_absent "--number-sections"
+}
+
+@test "frontmatter number_section disables automatic section numbering" {
+  setup_fake_pandoc
+  local input="$TEST_TEMP_DIR/frontmatter-number-section.md"
+  write_doc "$input" "---" "number_section: true" "---" "" "# Title" "" "## Introduction"
+
+  run "$MD2PDF" "$input" "$TEST_TEMP_DIR/out.pdf"
+
+  [ "$status" -eq 0 ]
+  assert_arg_absent "--number-sections"
+}
+
+@test "frontmatter number_sections is converted to pandoc numbersections" {
+  setup_fake_pandoc
+  local input="$TEST_TEMP_DIR/frontmatter-number-sections.md"
+  write_doc "$input" "---" "number_sections: true" "---" "" "# Title" "" "## Introduction"
+
+  run "$MD2PDF" "$input" "$TEST_TEMP_DIR/out.pdf"
+
+  [ "$status" -eq 0 ]
+  assert_arg_absent "--number-sections"
+  grep -qx -- "numbersections: true" "$MD2PDF_PANDOC_INPUT_LOG"
+  ! grep -qx -- "number_sections: true" "$MD2PDF_PANDOC_INPUT_LOG"
+}
+
+@test "--no-number-sections disables default automatic section numbering" {
+  setup_fake_pandoc
+  local input="$TEST_TEMP_DIR/no-number-sections.md"
+  write_doc "$input" "# Title" "" "## Introduction" "" "Body"
+
+  run "$MD2PDF" --no-number-sections "$input" "$TEST_TEMP_DIR/out.pdf"
+
+  [ "$status" -eq 0 ]
+  assert_arg_absent "--number-sections"
+  assert_arg_present "--metadata=numbersections:false"
+}
+
+@test "--number-sections overrides existing numbered h2 detection" {
+  setup_fake_pandoc
+  local input="$TEST_TEMP_DIR/force-numbered-h2.md"
+  write_doc "$input" "# Title" "" "## 1. Introduction" "" "Body"
+
+  run "$MD2PDF" --number-sections "$input" "$TEST_TEMP_DIR/out.pdf"
+
+  [ "$status" -eq 0 ]
+  assert_arg_present "--number-sections"
+  assert_arg_present "--metadata=numbersections:true"
+}
+
+@test "numbered markdown h2 disables automatic section numbering" {
+  setup_fake_pandoc
+  local input="$TEST_TEMP_DIR/numbered-h2.md"
+  write_doc "$input" "# Title" "" "## 1. Introduction" "" "Body"
+
+  run "$MD2PDF" "$input" "$TEST_TEMP_DIR/out.pdf"
+
+  [ "$status" -eq 0 ]
+  assert_arg_absent "--number-sections"
+}
+
+@test "numbered html h2 disables automatic section numbering" {
+  setup_fake_pandoc
+  local input="$TEST_TEMP_DIR/numbered-html-h2.md"
+  write_doc "$input" "# Title" "" "<h2>1. Introduction</h2>" "" "Body"
+
+  run "$MD2PDF" "$input" "$TEST_TEMP_DIR/out.pdf"
+
+  [ "$status" -eq 0 ]
+  assert_arg_absent "--number-sections"
+}
+
+@test "frontmatter toc false disables automatic toc" {
+  setup_fake_pandoc
+  local input="$TEST_TEMP_DIR/toc-false.md"
+  write_doc "$input" "---" "toc: false" "---" "" "# Title" "" "## Introduction"
+
+  run "$MD2PDF" "$input" "$TEST_TEMP_DIR/out.pdf"
+
+  [ "$status" -eq 0 ]
+  assert_arg_absent "--toc"
+}
+
+@test "--toc overrides frontmatter toc false" {
+  setup_fake_pandoc
+  local input="$TEST_TEMP_DIR/toc-override-true.md"
+  write_doc "$input" "---" "toc: false" "---" "" "# Title" "" "## Introduction"
+
+  run "$MD2PDF" --toc "$input" "$TEST_TEMP_DIR/out.pdf"
+
+  [ "$status" -eq 0 ]
+  assert_arg_present "--toc"
+  assert_arg_present "--metadata=toc:true"
+}
+
+@test "--no-toc overrides frontmatter toc true" {
+  setup_fake_pandoc
+  local input="$TEST_TEMP_DIR/toc-override-false.md"
+  write_doc "$input" "---" "toc: true" "---" "" "# Title" "" "## Introduction"
+
+  run "$MD2PDF" --no-toc "$input" "$TEST_TEMP_DIR/out.pdf"
+
+  [ "$status" -eq 0 ]
+  assert_arg_absent "--toc"
+  assert_arg_present "--metadata=toc:false"
+}


### PR DESCRIPTION
Adds explicit CLI controls for section numbering and TOC generation while honoring pandoc frontmatter defaults. Normalizes number_sections to pandoc's numbersections metadata, detects existing numbered H2 headings, and documents the new behavior. Adds fake-pandoc regression coverage plus a development prereq helper for bats-core. Verified with make test: 89 tests passed.