### PR TITLE
Add regression test for auto-created output parent directory (AG-8)

### DIFF
--- a/tests/output_resolution.bats
+++ b/tests/output_resolution.bats
@@ -23,3 +23,11 @@ load test_helper
   [ "$status" -eq 0 ]
   [ -f "$subdir/doc.pdf" ]
 }
+
+@test "auto-creates parent directory of output path" {
+  local nested="$TEST_TEMP_DIR/out/nested/deeper"
+  [ ! -d "$nested" ]
+  run "$MD2PDF" "$FIXTURES_DIR/sample.md" "$nested/x.pdf"
+  [ "$status" -eq 0 ]
+  [ -f "$nested/x.pdf" ]
+}


### PR DESCRIPTION
## Summary

- Closes [AG-8](https://linear.app/alexg0/issue/AG-8/auto-create-output-directory-parent-mkdir-p).
- The `mkdir -p` behavior was already shipped in the Ruby rewrite (`bin/md2pdf:500`, `FileUtils.mkdir_p(File.dirname(resolved))`), applied unconditionally before any backend lambda runs — so it covers all modes.
- This PR adds a regression test that mirrors the ticket's repro (`md2pdf sample.md out/nested/deeper/x.pdf` succeeds when none of the parents exist) so the behavior can't silently regress.

## Test plan

- [x] `bats tests/output_resolution.bats` — all 4 tests pass, including the new `auto-creates parent directory of output path`

🤖 Generated with [Claude Code](https://claude.com/claude-code)