### PR TITLE
Render mermaid fences natively

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Multi-engine Markdown to PDF converter. Supports 10 rendering backends with a un
 - Automatic title detection from first H1 heading
 - Isolated tool home directory to avoid global binary conflicts
 - Unicode character normalization for LaTeX engines
+- Native rendering of fenced ```` ```mermaid ```` blocks via `mmdc` (cached)
 - Per-mode warnings when options are unsupported
 
 ## Supported Modes
@@ -88,6 +89,8 @@ Common options:
   --number-sections   Number section headings
   --no-number-sections
                       Do not number section headings
+  --mermaid           Pre-render fenced ```mermaid blocks via mmdc (default)
+  --no-mermaid        Skip mermaid preprocessing
 
 Actions:
   --list-modes        List modes and install status
@@ -136,12 +139,27 @@ numbersections: false
 `number_sections:` is accepted by `md2pdf` and normalized to pandoc's
 `numbersections:` metadata key before rendering.
 
+## Mermaid diagrams
+
+Fenced ```` ```mermaid ```` blocks are rendered to cached PNGs via
+[mermaid-cli](https://github.com/mermaid-js/mermaid-cli) before the markdown is
+handed to the renderer. PNGs are cached in
+`${MD2PDF_TOOL_HOME}/cache/mermaid/mermaid-<hash>.png` keyed by a SHA-256 of
+the block contents, so repeated runs skip `mmdc`.
+
+If a document has no mermaid fences, `mmdc` is never invoked and is not a
+required dependency. When fences are present but `mmdc` is missing, `md2pdf`
+exits with instructions to install it (`md2pdf --install-deps` for the
+selected mode, or `npm i -g @mermaid-js/mermaid-cli`). Pass `--no-mermaid` to
+leave fences untouched.
+
 ## Configuration
 
 | Environment Variable | Description |
 |---------------------|-------------|
 | `MD2PDF_TOOL_HOME` | Override tool install root (default: `~/.local/share/md2pdf`) |
 | `MD2PDF_DEBUG=1` | Keep temporary files on failure for debugging |
+| `MMDC_PUPPETEER_CONFIG` | Path to a Puppeteer JSON config file passed to `mmdc -p` when set and existing |
 
 ## Testing
 

--- a/bin/md2pdf
+++ b/bin/md2pdf
@@ -26,6 +26,7 @@
 #   ./bin/md2pdf --mode go-md2pdf --check-deps
 #   ./bin/md2pdf --install-deps-all
 
+require "digest"
 require "fileutils"
 require "json"
 require "optparse"
@@ -54,6 +55,97 @@ DEFAULTS = {
   page_numbers: true,
   mode: "pandoc-xelatex",
 }.freeze
+
+MERMAID_NPM_PACKAGE = "@mermaid-js/mermaid-cli"
+MERMAID_BIN = "mmdc"
+
+# --- Mermaid preprocessor ---
+#
+# Detects fenced ```mermaid blocks (ignoring fences nested inside other code
+# blocks), renders each block to a cached PNG via mmdc, and rewrites the source
+# to reference the PNG.
+module MermaidPreprocessor
+  module_function
+
+  FENCE_OPEN_RE = /\A([ \t]*)(```+|~~~+)([^\n]*)\r?\n?\z/.freeze
+
+  def closing_fence?(line, fence_indent:, fence_delim:)
+    fence_char = fence_delim[0]
+    line.match?(/\A(?:#{Regexp.escape(fence_indent)}|[ \t]{0,3})#{Regexp.escape(fence_char)}{#{fence_delim.length},}[ \t]*\r?\n?\z/)
+  end
+
+  def detect_blocks(content)
+    blocks = []
+    in_fence = false
+    fence_lang = nil
+    fence_delim = nil
+    fence_indent = nil
+    block_open_start = nil
+    block_body_start = nil
+    pos = 0
+
+    content.each_line do |line|
+      line_start = pos
+      line_end = pos + line.length
+
+      if in_fence
+        if closing_fence?(line, fence_indent: fence_indent, fence_delim: fence_delim)
+          if fence_lang == "mermaid"
+            blocks << {
+              open_start: block_open_start,
+              block_end: line_end,
+              body: content[block_body_start...line_start],
+              indent: fence_indent,
+            }
+          end
+          in_fence = false
+        end
+      elsif (m = line.match(FENCE_OPEN_RE))
+        in_fence = true
+        fence_indent = m[1]
+        fence_delim = m[2]
+        fence_lang = m[3].strip.split(/\s+/).first.to_s.downcase
+        block_open_start = line_start
+        block_body_start = line_end
+      end
+
+      pos = line_end
+    end
+
+    blocks
+  end
+
+  def has_blocks?(content)
+    !detect_blocks(content).empty?
+  end
+
+  def process(content, cache_dir:, mmdc:, puppeteer_config:, tmpdir:)
+    blocks = detect_blocks(content)
+    return content if blocks.empty?
+
+    FileUtils.mkdir_p(cache_dir)
+    result = +""
+    cursor = 0
+
+    blocks.each_with_index do |block, idx|
+      result << content[cursor...block[:open_start]]
+      hash = Digest::SHA256.hexdigest(block[:body])[0, 12]
+      png = File.join(cache_dir, "mermaid-#{hash}.png")
+      unless File.exist?(png)
+        mmd = File.join(tmpdir, "mermaid-#{idx}-#{hash}.mmd")
+        File.write(mmd, block[:body])
+        cmd = [mmdc, "-i", mmd, "-o", png,
+               "--backgroundColor", "white", "--scale", "2", "--quiet"]
+        cmd += ["-p", puppeteer_config] if puppeteer_config
+        system(*cmd, exception: true)
+      end
+      result << "#{block[:indent]}![](#{png})\n"
+      cursor = block[:block_end]
+    end
+    result << content[cursor..]
+    result
+  end
+end
 
 LATEX_UNICODE = { "✅" => "[OK]", "⚠️" => "[!]", "✓" => "[x]", "≥" => ">=", "→" => "->" }.freeze
 PDFLATEX_EXTRA = { "—" => "--", "–" => "-", "'" => "'", "\u201c" => '"', "\u201d" => '"' }.freeze
@@ -202,7 +294,7 @@ MD_TO_PDF_RENDER = ->(ctx) do
 
   config = {
     dest: ctx[:output],
-    basedir: File.dirname(File.expand_path(ctx[:input])),
+    basedir: ctx[:source_dir],
     stylesheet: [css_file],
     document_title: ctx[:title],
     pdf_options: {
@@ -279,7 +371,7 @@ MODES = {
     label: "Pandoc + XeLaTeX", runtime: "pandoc, xelatex", alias_tag: " [alias: latex]",
     note: "Default mode. Pandoc + XeLaTeX with title block, margin/font/TOC support. 'latex' is an alias.",
     engine: "xelatex", font_check: true,
-    supports: %i[title author margin fontsize font toc page_numbers],
+    supports: %i[title author margin fontsize font toc page_numbers mermaid],
     deps: { cmds: %w[pandoc xelatex] },
     install: { brew: %w[pandoc], brew_cask: %w[basictex font-noto-serif] },
     binary: { system: "pandoc" },
@@ -289,7 +381,7 @@ MODES = {
     label: "Pandoc + LuaLaTeX", runtime: "pandoc, lualatex",
     note: "Pandoc + LuaLaTeX. Unicode font support like XeLaTeX, useful for comparing TeX engines.",
     engine: "lualatex", font_check: true,
-    supports: %i[title author margin fontsize font toc page_numbers],
+    supports: %i[title author margin fontsize font toc page_numbers mermaid],
     deps: { cmds: %w[pandoc lualatex] },
     install: { brew: %w[pandoc], brew_cask: %w[basictex font-noto-serif] },
     binary: { system: "pandoc" },
@@ -299,7 +391,7 @@ MODES = {
     label: "Pandoc + pdfLaTeX", runtime: "pandoc, pdflatex",
     note: "Pandoc + pdfLaTeX. Best with ASCII content; Unicode and custom fonts are limited.",
     engine: "pdflatex",
-    supports: %i[title author margin fontsize toc page_numbers],
+    supports: %i[title author margin fontsize toc page_numbers mermaid],
     deps: { cmds: %w[pandoc pdflatex] },
     install: { brew: %w[pandoc], brew_cask: %w[basictex] },
     binary: { system: "pandoc" },
@@ -309,7 +401,7 @@ MODES = {
     label: "Pandoc + wkhtmltopdf", runtime: "pandoc, wkhtmltopdf",
     note: "Pandoc HTML pipeline + wkhtmltopdf. Margin/font via CSS. Author metadata not mapped.",
     engine: "wkhtmltopdf",
-    supports: %i[title margin fontsize font toc page_numbers],
+    supports: %i[title margin fontsize font toc page_numbers mermaid],
     deps: { cmds: %w[pandoc wkhtmltopdf] },
     install: { require: { "pandoc" => "brew install pandoc", "wkhtmltopdf" => "install via your preferred package manager" } },
     binary: { system: "pandoc" },
@@ -319,7 +411,7 @@ MODES = {
     label: "Pandoc + WeasyPrint", runtime: "pandoc, weasyprint",
     note: "Pandoc HTML pipeline + WeasyPrint. Margin/font via CSS. Author metadata not mapped.",
     engine: "weasyprint",
-    supports: %i[title margin fontsize font toc page_numbers],
+    supports: %i[title margin fontsize font toc page_numbers mermaid],
     deps: { cmds: %w[pandoc weasyprint] },
     install: { brew: %w[pandoc weasyprint] },
     binary: { system: "pandoc" },
@@ -328,7 +420,7 @@ MODES = {
   "md-to-pdf" => {
     label: "Node/Puppeteer (md-to-pdf)", runtime: "node, npm",
     note: "Puppeteer-based. Supports title, margin, font-size. Author/auto-TOC not mapped.",
-    supports: %i[title margin fontsize font page_numbers],
+    supports: %i[title margin fontsize font page_numbers mermaid],
     deps: { cmds: %w[node], npm_bin: { package: "md-to-pdf", binary: "md-to-pdf" } },
     install: { npm: "md-to-pdf" },
     binary: { npm: { package: "md-to-pdf", bin: "md-to-pdf" } },
@@ -337,7 +429,7 @@ MODES = {
   "mdpdf" => {
     label: "Node/Puppeteer (mdpdf)", runtime: "node, npm",
     note: "Puppeteer-based. Maps title, border, font-size via stylesheet. Author/auto-TOC not mapped.",
-    supports: %i[title margin fontsize font page_numbers],
+    supports: %i[title margin fontsize font page_numbers mermaid],
     deps: { cmds: %w[node], npm_bin: { package: "mdpdf", binary: "mdpdf" } },
     install: { npm: "mdpdf" },
     binary: { npm: { package: "mdpdf", bin: "mdpdf" } },
@@ -346,7 +438,7 @@ MODES = {
   "go-md2pdf" => {
     label: "Go/fpdf", runtime: "go",
     note: "Non-browser renderer. Title/author/TOC supported. No CSS margin/font-size control.",
-    supports: %i[title author toc page_numbers],
+    supports: %i[title author toc page_numbers mermaid],
     deps: { cmds: %w[go], local_bin: "go-md2pdf/bin/md2pdf" },
     install: { go: "github.com/solworktech/md2pdf/v2/cmd/md2pdf@latest" },
     binary: { local: "go-md2pdf/bin/md2pdf" },
@@ -355,7 +447,7 @@ MODES = {
   "weasy-md2pdf" => {
     label: "Python/WeasyPrint", runtime: "python3, brew",
     note: "Python + WeasyPrint. Margin/font via stylesheet. Title/author/TOC not mapped.",
-    supports: %i[margin fontsize font page_numbers],
+    supports: %i[margin fontsize font page_numbers mermaid],
     deps: { cmds: %w[python3 weasyprint], local_bin: "python/weasy-md2pdf/bin/md2pdf" },
     install: { weasy: true },
     binary: { local: "python/weasy-md2pdf/bin/md2pdf" },
@@ -364,7 +456,7 @@ MODES = {
   "percollate" => {
     label: "Experimental HTML-first", runtime: "pandoc, node, npm", extra_tag: " [experimental]",
     note: "Experimental. Converts MD to HTML via pandoc, then renders through percollate.",
-    supports: %i[title author margin fontsize font toc page_numbers],
+    supports: %i[title author margin fontsize font toc page_numbers mermaid],
     deps: { cmds: %w[pandoc node], npm_bin: { package: "percollate", binary: "percollate" } },
     install: { npm: "percollate" },
     binary: { npm: { package: "percollate", bin: "percollate" } },
@@ -385,6 +477,7 @@ class Md2Pdf
     @toc = nil
     @number_sections = nil
     @page_numbers = DEFAULTS[:page_numbers]
+    @mermaid = true
     @font_explicit = false
     @title = nil
     @author = nil
@@ -424,6 +517,7 @@ class Md2Pdf
       opts.on("--[no-]toc", "Table of contents (default: on unless frontmatter sets toc)") { |v| @toc = v }
       opts.on("--[no-]number-sections", "Number section headings (default: on unless frontmatter or numbered H2 controls it)") { |v| @number_sections = v }
       opts.on("--[no-]page-numbers", "Page numbers (default: on)") { |v| @page_numbers = v }
+      opts.on("--[no-]mermaid", "Pre-render fenced ```mermaid blocks via mmdc (default: on)") { |v| @mermaid = v }
       opts.on("--list-modes", "List modes and install status") { @action = :list_modes }
       opts.on("--check-deps", "Check deps for selected mode") { @action = :check_deps }
       opts.on("--check-deps-all", "Check deps for all modes") { @action = :check_deps_all }
@@ -460,8 +554,9 @@ class Md2Pdf
   def list_modes
     MODES.each do |name, info|
       status = check_mode_deps(name) ? "installed" : "missing deps"
+      features = info[:supports].include?(:mermaid) ? " features=mermaid" : ""
       extra = info[:alias_tag] || info[:extra_tag] || ""
-      printf "%-20s %-28s runtime=%-20s status=%s%s\n", name, info[:label], info[:runtime], status, extra
+      printf "%-20s %-28s runtime=%-20s status=%s%s%s\n", name, info[:label], info[:runtime], status, features, extra
     end
   end
 
@@ -500,9 +595,11 @@ class Md2Pdf
     FileUtils.mkdir_p(File.dirname(resolved))
     tmpdir = new_temp_dir
     source_content = File.read(@input_file, encoding: "utf-8")
+    input_path = preprocess_mermaid(source_content, tmpdir) || @input_file
 
     ctx = {
-      binary: binary, input: @input_file, output: resolved, tmpdir: tmpdir,
+      binary: binary, input: input_path, output: resolved, tmpdir: tmpdir,
+      source_dir: File.dirname(File.expand_path(@input_file)),
       title: detect_title, author: @author, date: latex_date,
       margin: @margin, fontsize: @fontsize, font: @font_family,
       toc: RenderHelpers.resolve_toc(source_content, @toc, DEFAULTS[:toc]),
@@ -571,6 +668,7 @@ class Md2Pdf
       run_cmd({ "GOBIN" => bin_dir }, "go", "install", recipe[:go])
     end
     ensure_weasy_env if recipe[:weasy]
+    ensure_npm_package(MERMAID_NPM_PACKAGE) if MODES.fetch(name)[:supports].include?(:mermaid)
   end
 
   # --- Config-driven unmapped option warnings ---
@@ -668,8 +766,41 @@ class Md2Pdf
     dir = File.join(@tool_home, "npm", package)
     FileUtils.mkdir_p(dir)
     pkg_json = File.join(dir, "package.json")
-    File.write(pkg_json, JSON.generate({ name: "md2pdf-rb-#{package}", private: true })) unless File.exist?(pkg_json)
+    unless File.exist?(pkg_json)
+      sanitized = "md2pdf-rb-#{package.gsub(/[^a-z0-9-]/i, "-").downcase}".gsub(/-+/, "-")
+      File.write(pkg_json, JSON.generate({ name: sanitized, private: true }))
+    end
     run_cmd("npm", "install", "--no-save", package, chdir: dir)
+  end
+
+  def preprocess_mermaid(content, tmpdir)
+    return nil unless @mermaid
+    return nil unless cfg[:supports].include?(:mermaid)
+    return nil unless MermaidPreprocessor.has_blocks?(content)
+
+    mmdc = locate_mmdc
+    unless mmdc
+      abort "mermaid blocks detected but mmdc not installed. Run '#{$PROGRAM_NAME} --install-deps' or 'npm i -g @mermaid-js/mermaid-cli'."
+    end
+
+    cache_dir = File.join(@tool_home, "cache", "mermaid")
+    puppeteer_config = ENV["MMDC_PUPPETEER_CONFIG"]
+    puppeteer_config = nil unless puppeteer_config && File.file?(puppeteer_config)
+
+    rendered = MermaidPreprocessor.process(content,
+      cache_dir: cache_dir, mmdc: mmdc,
+      puppeteer_config: puppeteer_config, tmpdir: tmpdir)
+
+    path = File.join(tmpdir, "mermaid-#{File.basename(@input_file)}")
+    File.write(path, rendered)
+    path
+  end
+
+  def locate_mmdc
+    local = File.join(@tool_home, "npm", MERMAID_NPM_PACKAGE, "node_modules", ".bin", MERMAID_BIN)
+    return local if File.executable?(local)
+    return MERMAID_BIN if have_cmd(MERMAID_BIN)
+    nil
   end
 
   def ensure_weasy_env

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -50,3 +50,62 @@
   - `git diff --check` passed.
   - `make test` could not run because `bats-core` is not installed.
 - Lessons: none; no correction or postmortem occurred.
+
+## AG-5: Native fenced ```mermaid rendering
+
+- [x] Restate goal + acceptance criteria
+  - Goal: Pre-render fenced ```mermaid blocks to cached PNGs via `mmdc` so callers don't have to preprocess markdown.
+  - Acceptance: cache hits skip mmdc; no fences → no mmdc dep; missing mmdc with fences fails with actionable message; `--install-deps` installs mermaid-cli into `MD2PDF_TOOL_HOME`; `--list-modes` shows mermaid support; `--no-mermaid` disables preprocessing.
+- [x] Locate existing implementation / patterns
+  - Modes have `supports:` declaration consumed by warnings + display.
+  - `ensure_npm_package` already installs locally to `${MD2PDF_TOOL_HOME}/npm/<package>`; reused for the scoped `@mermaid-js/mermaid-cli` package after sanitizing the package.json `name` field.
+- [x] Design: minimal approach + key decisions
+  - New `MermaidPreprocessor` module: line-by-line fence walk that ignores nested fences (delimiter+indent must match to close).
+  - `Md2Pdf#preprocess_mermaid` runs before render lambda; rewritten markdown lives in tmpdir and `ctx[:input]` is swapped, leaving `resource_path` based on the original file.
+  - `:mermaid` added to every mode's `supports:` (all current modes consume markdown).
+- [x] Implement smallest safe slice
+- [x] Add/adjust tests (`tests/mermaid_preprocessing.bats`)
+- [x] Run verification
+
+## AG-5 Results
+
+- Mermaid blocks render to `${MD2PDF_TOOL_HOME}/cache/mermaid/mermaid-<sha12>.png`; fences replaced with absolute-path image refs.
+- `mmdc` invoked as `mmdc -i tmp.mmd -o png --backgroundColor white --scale 2 --quiet`, with `-p $MMDC_PUPPETEER_CONFIG` appended when the env var points at an existing file.
+- `--install-deps` for any mode also installs `@mermaid-js/mermaid-cli` locally (scoped names sanitized in package.json).
+- `--list-modes` now shows `features=mermaid`.
+- `--no-mermaid` short-circuits preprocessing; missing mmdc with fences aborts with actionable message.
+- Verification:
+  - `ruby -c bin/md2pdf` — Syntax OK.
+  - `bats tests/` — 93 tests pass (4 new mermaid tests).
+  - End-to-end: rendered a doc with a real graph through pandoc-xelatex; second run reused the cached PNG.
+
+## AG-6: Mermaid regression follow-up
+
+- [x] Restate goal + acceptance criteria
+  - Goal: Fix the mermaid preprocessing regressions found in review without widening scope.
+  - Acceptance: relative assets still resolve from the original markdown directory after preprocessing; mermaid blocks nested in list indentation keep that indentation; valid longer closing fences still render.
+- [x] Locate existing implementation / patterns
+  - Mermaid preprocessing lives in `MermaidPreprocessor` inside `bin/md2pdf`.
+  - `md-to-pdf` derives `basedir` from `ctx[:input]`, which now changes after preprocessing.
+- [x] Design: minimal approach + key decisions
+  - Preserve the original source directory separately in render context instead of relying on the rewritten temp file path.
+  - Store fence indentation in the detected block metadata and reuse it when emitting the replacement image.
+  - Relax closing-fence matching to accept the same delimiter character with at least the opening fence length.
+- [x] Implement smallest safe slice
+- [x] Add/adjust tests
+- [x] Run verification (lint/tests/build/manual repro)
+- [x] Summarize changes + verification story
+- [x] Record lessons (if any)
+
+## AG-6 Results
+
+- Mermaid replacements now preserve the original fence indentation, so list-nested diagrams remain inside their list item structure.
+- Closing-fence detection now accepts the same fence character repeated at least as many times as the opener, which covers valid longer closers like ```` after ```mermaid.
+- `md-to-pdf` now keeps `basedir` pointed at the original markdown directory even when mermaid preprocessing rewrites the input into a temp file.
+- Added regression coverage in `tests/mermaid_preprocessing.bats` for list indentation, longer closing fences, and `md-to-pdf` basedir preservation.
+- Verification:
+  - `ruby -c bin/md2pdf` — Syntax OK.
+  - `bats tests/mermaid_preprocessing.bats` — 7 tests passed.
+  - `bats tests/` — 96 tests passed.
+  - `git diff --check` — passed.
+- Lessons: none; the regressions were caught by review before merge, so no new prevention rule was needed beyond the added tests.

--- a/tests/mermaid_preprocessing.bats
+++ b/tests/mermaid_preprocessing.bats
@@ -1,0 +1,275 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+# Build a fake-bin directory containing fake pandoc + xelatex (so we don't need
+# the real renderer toolchain). The fake pandoc logs argv and the input markdown
+# it received, then writes an empty PDF to -o. The fake xelatex always succeeds.
+setup_fake_pandoc() {
+  mkdir -p "$TEST_TEMP_DIR/fake-bin"
+
+  cat > "$TEST_TEMP_DIR/fake-bin/xelatex" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+
+  cat > "$TEST_TEMP_DIR/fake-bin/pandoc" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$MD2PDF_PANDOC_ARGS_LOG"
+cp "$1" "$MD2PDF_PANDOC_INPUT_LOG"
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-o" ]; then
+    shift
+    touch "$1"
+    exit 0
+  fi
+  shift
+done
+exit 0
+SH
+
+  chmod +x "$TEST_TEMP_DIR/fake-bin/pandoc" "$TEST_TEMP_DIR/fake-bin/xelatex"
+  export PATH="$TEST_TEMP_DIR/fake-bin:$PATH"
+  export MD2PDF_PANDOC_ARGS_LOG="$TEST_TEMP_DIR/pandoc-args.txt"
+  export MD2PDF_PANDOC_INPUT_LOG="$TEST_TEMP_DIR/pandoc-input.md"
+}
+
+# Add a fake mmdc that records each invocation and produces an empty PNG.
+setup_fake_mmdc() {
+  export MD2PDF_MMDC_CALLS_LOG="$TEST_TEMP_DIR/mmdc-calls.log"
+  : > "$MD2PDF_MMDC_CALLS_LOG"
+
+  cat > "$TEST_TEMP_DIR/fake-bin/mmdc" <<'SH'
+#!/usr/bin/env bash
+echo "$@" >> "$MD2PDF_MMDC_CALLS_LOG"
+out=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-o" ]; then
+    shift
+    out="$1"
+  fi
+  shift
+done
+[ -n "$out" ] && touch "$out"
+exit 0
+SH
+  chmod +x "$TEST_TEMP_DIR/fake-bin/mmdc"
+}
+
+setup_fake_md_to_pdf() {
+  mkdir -p "$TEST_TEMP_DIR/fake-bin"
+  mkdir -p "$MD2PDF_TOOL_HOME/npm/md-to-pdf/node_modules/.bin"
+  export MD2PDF_CONFIG_LOG="$TEST_TEMP_DIR/md-to-pdf-config.json"
+
+  cat > "$TEST_TEMP_DIR/fake-bin/node" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+
+  cat > "$MD2PDF_TOOL_HOME/npm/md-to-pdf/node_modules/.bin/md-to-pdf" <<'SH'
+#!/usr/bin/env bash
+config=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--config-file" ]; then
+    shift
+    config="$1"
+  fi
+  shift
+done
+cp "$config" "$MD2PDF_CONFIG_LOG"
+exit 0
+SH
+
+  chmod +x "$TEST_TEMP_DIR/fake-bin/node" "$MD2PDF_TOOL_HOME/npm/md-to-pdf/node_modules/.bin/md-to-pdf"
+  export PATH="$TEST_TEMP_DIR/fake-bin:$PATH"
+}
+
+mmdc_call_count() {
+  if [ -s "$MD2PDF_MMDC_CALLS_LOG" ]; then
+    awk 'END { print NR }' "$MD2PDF_MMDC_CALLS_LOG"
+  else
+    echo 0
+  fi
+}
+
+write_mermaid_doc() {
+  local path="$1"
+  cat > "$path" <<'EOF'
+# Title
+
+```mermaid
+graph TD
+    A --> B
+```
+
+End.
+EOF
+}
+
+@test "mermaid block is rendered with mmdc and reused from cache on second run" {
+  setup_fake_pandoc
+  setup_fake_mmdc
+
+  local input="$TEST_TEMP_DIR/with-mermaid.md"
+  write_mermaid_doc "$input"
+
+  run "$MD2PDF" "$input" "$TEST_TEMP_DIR/out1.pdf"
+  [ "$status" -eq 0 ]
+  [ -f "$TEST_TEMP_DIR/out1.pdf" ]
+  [ "$(mmdc_call_count)" -eq 1 ]
+
+  # Cached PNG should now exist in the tool home cache directory.
+  shopt -s nullglob
+  cached=( "$MD2PDF_TOOL_HOME"/cache/mermaid/mermaid-*.png )
+  [ "${#cached[@]}" -eq 1 ]
+
+  run "$MD2PDF" "$input" "$TEST_TEMP_DIR/out2.pdf"
+  [ "$status" -eq 0 ]
+  [ -f "$TEST_TEMP_DIR/out2.pdf" ]
+  # Second run hits the cache, so mmdc should NOT have been invoked again.
+  [ "$(mmdc_call_count)" -eq 1 ]
+
+  # The pandoc input from the second run should reference the cached PNG and
+  # contain no remaining mermaid fence.
+  ! grep -q '^```mermaid' "$MD2PDF_PANDOC_INPUT_LOG"
+  grep -q "${cached[0]}" "$MD2PDF_PANDOC_INPUT_LOG"
+}
+
+@test "input with no mermaid blocks does not require mmdc" {
+  setup_fake_pandoc
+  setup_fake_mmdc
+
+  local input="$TEST_TEMP_DIR/plain.md"
+  cat > "$input" <<'EOF'
+# Title
+
+Just plain text, no diagrams here.
+
+```bash
+echo hi
+```
+EOF
+
+  run "$MD2PDF" "$input" "$TEST_TEMP_DIR/out.pdf"
+  [ "$status" -eq 0 ]
+  [ -f "$TEST_TEMP_DIR/out.pdf" ]
+  # No mermaid blocks → mmdc must not have been invoked.
+  [ "$(mmdc_call_count)" -eq 0 ]
+}
+
+@test "--no-mermaid leaves the fence untouched" {
+  setup_fake_pandoc
+  setup_fake_mmdc
+
+  local input="$TEST_TEMP_DIR/skip-mermaid.md"
+  write_mermaid_doc "$input"
+
+  run "$MD2PDF" --no-mermaid "$input" "$TEST_TEMP_DIR/out.pdf"
+  [ "$status" -eq 0 ]
+  [ -f "$TEST_TEMP_DIR/out.pdf" ]
+
+  # mmdc must not have been invoked when --no-mermaid is set.
+  [ "$(mmdc_call_count)" -eq 0 ]
+
+  # The original mermaid fence should still be present in what pandoc received.
+  grep -q '^```mermaid' "$MD2PDF_PANDOC_INPUT_LOG"
+  grep -q '^graph TD' "$MD2PDF_PANDOC_INPUT_LOG"
+}
+
+@test "fenced mermaid nested inside another code block is ignored" {
+  setup_fake_pandoc
+  setup_fake_mmdc
+
+  local input="$TEST_TEMP_DIR/nested-fence.md"
+  cat > "$input" <<'EOF'
+# Title
+
+````markdown
+```mermaid
+graph TD
+    A --> B
+```
+````
+
+End.
+EOF
+
+  run "$MD2PDF" "$input" "$TEST_TEMP_DIR/out.pdf"
+  [ "$status" -eq 0 ]
+  # The inner fence is part of an outer fence, so mermaid preprocessing
+  # should not run and mmdc should not have been invoked.
+  [ "$(mmdc_call_count)" -eq 0 ]
+  grep -q '```mermaid' "$MD2PDF_PANDOC_INPUT_LOG"
+}
+
+@test "mermaid block inside a list preserves indentation" {
+  setup_fake_pandoc
+  setup_fake_mmdc
+
+  local input="$TEST_TEMP_DIR/list-mermaid.md"
+  cat > "$input" <<'EOF'
+# Title
+
+- item before
+
+  ```mermaid
+  graph TD
+      A --> B
+  ```
+
+  item after
+EOF
+
+  run "$MD2PDF" "$input" "$TEST_TEMP_DIR/out.pdf"
+  [ "$status" -eq 0 ]
+  [ "$(mmdc_call_count)" -eq 1 ]
+  grep -q '^  !\[\](' "$MD2PDF_PANDOC_INPUT_LOG"
+  grep -q '^  item after$' "$MD2PDF_PANDOC_INPUT_LOG"
+}
+
+@test "mermaid block with longer closing fence is still rendered" {
+  setup_fake_pandoc
+  setup_fake_mmdc
+
+  local input="$TEST_TEMP_DIR/long-close-mermaid.md"
+  cat > "$input" <<'EOF'
+# Title
+
+```mermaid
+graph TD
+    A --> B
+````
+EOF
+
+  run "$MD2PDF" "$input" "$TEST_TEMP_DIR/out.pdf"
+  [ "$status" -eq 0 ]
+  [ "$(mmdc_call_count)" -eq 1 ]
+  ! grep -q '^```mermaid' "$MD2PDF_PANDOC_INPUT_LOG"
+  grep -q '!\[\](' "$MD2PDF_PANDOC_INPUT_LOG"
+}
+
+@test "md-to-pdf keeps basedir anchored to the source document directory" {
+  setup_fake_md_to_pdf
+  setup_fake_mmdc
+
+  local docs_dir="$TEST_TEMP_DIR/docs"
+  mkdir -p "$docs_dir"
+  touch "$docs_dir/image.png"
+
+  local input="$docs_dir/with-assets.md"
+  cat > "$input" <<'EOF'
+# Title
+
+![local](image.png)
+
+```mermaid
+graph TD
+    A --> B
+```
+EOF
+
+  run "$MD2PDF" --mode md-to-pdf "$input" "$TEST_TEMP_DIR/out.pdf"
+  [ "$status" -eq 0 ]
+  [ "$(mmdc_call_count)" -eq 1 ]
+  grep -F "\"basedir\":\"$docs_dir\"" "$MD2PDF_CONFIG_LOG"
+}


### PR DESCRIPTION
Adds native preprocessing for fenced mermaid blocks, rendering them to cached PNGs via mmdc before handing markdown to each renderer. Adds --mermaid/--no-mermaid, installs @mermaid-js/mermaid-cli with mode dependencies, and documents the cache plus MMDC_PUPPETEER_CONFIG behavior. Preserves markdown structure for indented fences, supports longer valid closing fences, and keeps md-to-pdf relative asset resolution anchored to the source document directory. Adds Bats coverage for caching, opt-out behavior, missing mermaid use cases, indentation, longer fences, and md-to-pdf basedir handling.