### PR TITLE
Add support for concatenated multi-file input

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,12 +73,14 @@ brew install --cask font-noto-serif
 ## Usage
 
 ```
-Usage: md2pdf [options] input.md [output.pdf]
+Usage: md2pdf [options] input.md [input2.md ...] [output.pdf | -o output.pdf]
 
 Common options:
   --mode MODE         Renderer mode (default: pandoc-xelatex)
   -t TITLE            PDF title (default: first # H1 from file, or filename)
   -a AUTHOR           Author line (default: none)
+  -o, --output PATH   Output PDF path (required when passing multiple inputs
+                      unless the last positional ends in .pdf)
   --font FONT         Preferred body font where supported (default: Noto Serif)
   -m MARGIN           Page margin (default: 1in)
   -s SIZE             Font size (default: 11pt)
@@ -110,6 +112,12 @@ md2pdf README.md
 # Specify output file
 md2pdf README.md output.pdf
 
+# Concatenate multiple inputs into a single PDF (last positional .pdf is output)
+md2pdf intro.md chapter1.md chapter2.md book.pdf
+
+# Same, with explicit -o (all positionals are inputs)
+md2pdf -o book.pdf intro.md chapter1.md chapter2.md
+
 # Use a different engine
 md2pdf --mode pandoc-lualatex README.md
 
@@ -125,6 +133,15 @@ md2pdf --list-modes
 # Check if dependencies are met
 md2pdf --mode go-md2pdf --check-deps
 ```
+
+### Multiple inputs
+
+When multiple input files are passed, they are concatenated (separated by a
+blank line) and rendered as a single PDF. Title auto-detection runs on the
+first input only. YAML frontmatter from the first input is preserved;
+frontmatter blocks in subsequent inputs are stripped silently. For pandoc
+modes, the resource path includes every input file's directory, so embedded
+images resolve relative to whichever input referenced them.
 
 Pandoc modes also honor YAML frontmatter for table-of-contents and section
 numbering control:

--- a/bin/md2pdf
+++ b/bin/md2pdf
@@ -482,7 +482,7 @@ class Md2Pdf
     @title = nil
     @author = nil
     @action = :render
-    @input_file = nil
+    @input_files = []
     @output_file = nil
     @warnings = []
     @temp_dirs = []
@@ -507,10 +507,11 @@ class Md2Pdf
   def parse_args(argv)
     args = argv.dup
     parser = OptionParser.new do |opts|
-      opts.banner = "Usage: #{$PROGRAM_NAME} [options] input.md [output.pdf]"
+      opts.banner = "Usage: #{$PROGRAM_NAME} [options] input.md [input2.md ...] [output.pdf | -o output.pdf]"
       opts.on("--mode MODE", "Renderer mode (default: #{DEFAULTS[:mode]})") { |v| @mode = v }
       opts.on("-t TITLE", "PDF title") { |v| @title = v }
       opts.on("-a AUTHOR", "Author line") { |v| @author = v }
+      opts.on("-o PATH", "--output PATH", "Output PDF path (required when passing multiple inputs)") { |v| @output_file = v }
       opts.on("--font FONT", "Body font") { |v| @font_family = v; @font_explicit = true }
       opts.on("-m MARGIN", "Page margin (default: #{DEFAULTS[:margin]})") { |v| @margin = v }
       opts.on("-s SIZE", "Font size (default: #{DEFAULTS[:fontsize]})") { |v| @fontsize = v }
@@ -529,9 +530,17 @@ class Md2Pdf
     remaining = parser.parse(args)
     @mode = "pandoc-xelatex" if @mode == "latex"
     abort "Unknown mode: #{@mode}" unless MODES.key?(@mode)
-    @input_file = remaining.shift
-    @output_file = remaining.shift
-    abort "Unexpected extra arguments: #{remaining.join(" ")}" unless remaining.empty?
+
+    if @output_file
+      @input_files = remaining
+    elsif remaining.size > 1 && remaining.last.downcase.end_with?(".pdf")
+      @output_file = remaining.pop
+      @input_files = remaining
+    elsif remaining.size > 1
+      abort "specify output with -o when passing multiple inputs"
+    else
+      @input_files = remaining
+    end
   end
 
   # --- Actions ---
@@ -581,8 +590,8 @@ class Md2Pdf
   # --- Unified render ---
 
   def render
-    abort "Usage: #{$PROGRAM_NAME} [options] input.md [output.pdf]\nRun with --help for details." if @input_file.nil?
-    abort "File not found: #{@input_file}" unless File.file?(@input_file)
+    abort "Usage: #{$PROGRAM_NAME} [options] input.md [input2.md ...] [output.pdf | -o output.pdf]\nRun with --help for details." if @input_files.empty?
+    @input_files.each { |f| abort "File not found: #{f}" unless File.file?(f) }
 
     unless check_mode_deps(@mode)
       abort "Dependencies missing for mode '#{@mode}'. Run: #{$PROGRAM_NAME} --mode #{@mode} --install-deps"
@@ -594,12 +603,13 @@ class Md2Pdf
     resolved = resolve_output
     FileUtils.mkdir_p(File.dirname(resolved))
     tmpdir = new_temp_dir
-    source_content = File.read(@input_file, encoding: "utf-8")
-    input_path = preprocess_mermaid(source_content, tmpdir) || @input_file
+    effective_input = prepare_input(tmpdir)
+    source_content = File.read(effective_input, encoding: "utf-8")
+    input_path = preprocess_mermaid(source_content, tmpdir) || effective_input
 
     ctx = {
       binary: binary, input: input_path, output: resolved, tmpdir: tmpdir,
-      source_dir: File.dirname(File.expand_path(@input_file)),
+      source_dir: File.dirname(File.expand_path(@input_files.first)),
       title: detect_title, author: @author, date: latex_date,
       margin: @margin, fontsize: @fontsize, font: @font_family,
       toc: RenderHelpers.resolve_toc(source_content, @toc, DEFAULTS[:toc]),
@@ -608,12 +618,34 @@ class Md2Pdf
       engine: cfg[:engine],
       number_sections: RenderHelpers.resolve_number_sections(source_content, @number_sections),
       number_sections_override: @number_sections,
-      resource_path: "#{File.dirname(File.expand_path(@input_file))}:.:#{@script_dir}",
+      resource_path: build_resource_path,
     }
 
     cmds = cfg[:render].call(ctx)
     cmds.each { |cmd| run_cmd(*cmd) }
     puts resolved
+  end
+
+  def prepare_input(tmpdir)
+    return @input_files.first if @input_files.size == 1
+
+    combined = @input_files.each_with_index.map do |path, idx|
+      content = File.read(path, encoding: "utf-8")
+      idx.zero? ? content : strip_frontmatter(content)
+    end.join("\n\n")
+
+    path = File.join(tmpdir, "concatenated.md")
+    File.write(path, combined)
+    path
+  end
+
+  def strip_frontmatter(content)
+    content.sub(/\A(?:\uFEFF)?---[ \t]*\r?\n.*?\r?\n---[ \t]*(?:\r?\n|\z)/m, "")
+  end
+
+  def build_resource_path
+    dirs = @input_files.map { |f| File.dirname(File.expand_path(f)) }
+    (dirs + [".", @script_dir]).uniq.join(":")
   end
 
   # --- Binary resolution (config-driven) ---
@@ -691,19 +723,21 @@ class Md2Pdf
 
   def detect_title
     return @title if @title
-    File.foreach(@input_file) do |line|
+    first = @input_files.first
+    File.foreach(first) do |line|
       return line.sub(/^#\s+/, "").strip if line.start_with?("# ")
     end
-    File.basename(@input_file, ".*")
+    File.basename(first, ".*")
   end
 
   def resolve_output
     return @output_file if @output_file
-    File.join(File.dirname(@input_file), "#{File.basename(@input_file, ".md")}.pdf")
+    first = @input_files.first
+    File.join(File.dirname(first), "#{File.basename(first, ".md")}.pdf")
   end
 
   def latex_date
-    File.mtime(@input_file).strftime("%B %d, %Y")
+    File.mtime(@input_files.first).strftime("%B %d, %Y")
   rescue
     Time.now.strftime("%B %d, %Y")
   end
@@ -791,7 +825,8 @@ class Md2Pdf
       cache_dir: cache_dir, mmdc: mmdc,
       puppeteer_config: puppeteer_config, tmpdir: tmpdir)
 
-    path = File.join(tmpdir, "mermaid-#{File.basename(@input_file)}")
+    basename = @input_files.size == 1 ? File.basename(@input_files.first) : "concatenated.md"
+    path = File.join(tmpdir, "mermaid-#{basename}")
     File.write(path, rendered)
     path
   end

--- a/tests/argument_parsing.bats
+++ b/tests/argument_parsing.bats
@@ -49,10 +49,15 @@ load test_helper
   [ "$status" -ne 0 ]
 }
 
-@test "extra positional arguments fail" {
-  run "$MD2PDF" input.md output.pdf extra.txt
+@test "multiple inputs without -o or trailing .pdf fail" {
+  run "$MD2PDF" input.md another.md
   [ "$status" -ne 0 ]
-  [[ "$output" == *"Unexpected extra"* ]]
+  [[ "$output" == *"specify output with -o"* ]]
+}
+
+@test "-o requires a value" {
+  run "$MD2PDF" -o
+  [ "$status" -ne 0 ]
 }
 
 @test "unknown mode fails" {

--- a/tests/multi_input.bats
+++ b/tests/multi_input.bats
@@ -1,0 +1,120 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+has_pandoc_xelatex() {
+  command -v pandoc >/dev/null 2>&1 && command -v xelatex >/dev/null 2>&1
+}
+
+@test "two inputs concatenate into a single PDF" {
+  has_pandoc_xelatex || skip "pandoc and xelatex not available"
+
+  local a="$TEST_TEMP_DIR/a.md"
+  local b="$TEST_TEMP_DIR/b.md"
+  local out="$TEST_TEMP_DIR/combined.pdf"
+  cat > "$a" <<'MD'
+# First Document
+
+Body of A.
+MD
+  cat > "$b" <<'MD'
+## Section From B
+
+Body of B.
+MD
+  run "$MD2PDF" --no-toc "$a" "$b" "$out"
+  [ "$status" -eq 0 ]
+  [ -s "$out" ]
+
+  run pdftotext -layout "$out" -
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"First Document"* ]]
+  [[ "$output" == *"Section From B"* ]]
+  # Page 1 starts with input 1's title
+  page1="${output%%$'\f'*}"
+  [[ "$page1" == *"First Document"* ]]
+}
+
+@test "image referenced from second input directory resolves" {
+  has_pandoc_xelatex || skip "pandoc and xelatex not available"
+  command -v python3 >/dev/null 2>&1 || skip "python3 not available"
+
+  local d1="$TEST_TEMP_DIR/dir1"
+  local d2="$TEST_TEMP_DIR/dir2"
+  mkdir -p "$d1" "$d2"
+  cat > "$d1/a.md" <<'MD'
+# Doc A
+
+Hello.
+MD
+  cat > "$d2/b.md" <<'MD'
+## Doc B
+
+![pic](pic.png)
+MD
+  python3 -c "import base64,sys; sys.stdout.buffer.write(base64.b64decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkAAIAAAoAAv/lxKUAAAAASUVORK5CYII='))" > "$d2/pic.png"
+
+  local out="$TEST_TEMP_DIR/out.pdf"
+  run "$MD2PDF" --no-toc "$d1/a.md" "$d2/b.md" -o "$out"
+  [ "$status" -eq 0 ]
+  [ -s "$out" ]
+}
+
+@test "multiple inputs without -o errors with helpful message" {
+  run "$MD2PDF" "$FIXTURES_DIR/sample.md" "$FIXTURES_DIR/no-heading.md"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"specify output with -o when passing multiple inputs"* ]]
+}
+
+@test "trailing .pdf positional is treated as output for multi-input" {
+  has_pandoc_xelatex || skip "pandoc and xelatex not available"
+
+  local out="$TEST_TEMP_DIR/trailing.pdf"
+  run "$MD2PDF" --no-toc "$FIXTURES_DIR/sample.md" "$FIXTURES_DIR/no-heading.md" "$out"
+  [ "$status" -eq 0 ]
+  [ -s "$out" ]
+}
+
+@test "-o output with multiple inputs writes to specified path" {
+  has_pandoc_xelatex || skip "pandoc and xelatex not available"
+
+  local out="$TEST_TEMP_DIR/explicit.pdf"
+  run "$MD2PDF" --no-toc -o "$out" "$FIXTURES_DIR/sample.md" "$FIXTURES_DIR/no-heading.md"
+  [ "$status" -eq 0 ]
+  [ -s "$out" ]
+}
+
+@test "frontmatter from first input is preserved, subsequent stripped" {
+  has_pandoc_xelatex || skip "pandoc and xelatex not available"
+
+  local a="$TEST_TEMP_DIR/a.md"
+  local b="$TEST_TEMP_DIR/b.md"
+  local out="$TEST_TEMP_DIR/frontmatter.pdf"
+  # First input sets toc:false via frontmatter; CLI does not override.
+  cat > "$a" <<'MD'
+---
+toc: false
+---
+# Doc A
+
+Body.
+MD
+  # Second input has frontmatter that would set toc:true if not stripped.
+  cat > "$b" <<'MD'
+---
+toc: true
+---
+## Doc B
+
+Body.
+MD
+  run "$MD2PDF" "$a" "$b" "$out"
+  [ "$status" -eq 0 ]
+  [ -s "$out" ]
+
+  run pdftotext -layout "$out" -
+  [ "$status" -eq 0 ]
+  # No "Contents" / "Table of Contents" heading should appear since first
+  # frontmatter wins (toc:false).
+  [[ "$output" != *"Contents"* ]]
+}


### PR DESCRIPTION
This adds support for rendering multiple Markdown inputs into a single PDF, with -o/--output support and trailing .pdf positional output detection for multi-file runs. It concatenates inputs through a temporary Markdown file, preserves frontmatter from the first input, strips frontmatter from later inputs, and extends pandoc resource-path handling across all input directories. The PR also updates the README usage examples and adds argument parsing plus multi-input integration tests.
