### PR TITLE
Read per-document options from YAML frontmatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,18 +144,40 @@ frontmatter blocks in subsequent inputs are stripped silently. For pandoc
 modes, the resource path includes every input file's directory, so embedded
 images resolve relative to whichever input referenced them.
 
-Pandoc modes also honor YAML frontmatter for table-of-contents and section
-numbering control:
+### Per-document options via YAML frontmatter
+
+Pandoc modes honor a YAML frontmatter block at the top of the markdown file
+for per-document overrides:
 
 ```yaml
 ---
-toc: false
-numbersections: false
+title:        # string, overrides H1 auto-detection
+author:       # string
+date:         # string, overrides file mtime
+margin:       # bare value like 0.75in or 20mm
+fontsize:     # e.g. 10pt
+font:         # e.g. Noto Serif
+page_numbers: # bool
+toc:          # bool
+numbersections: # bool
 ---
 ```
 
-`number_sections:` is accepted by `md2pdf` and normalized to pandoc's
-`numbersections:` metadata key before rendering.
+**Precedence:** CLI flag > frontmatter > built-in default.
+
+**Key aliases (normalized to canonical):**
+
+* `font_size` -> `fontsize`
+* `page-numbers`, `pageNumbers` -> `page_numbers`
+* `number_sections`, `number_section` -> `numbersections`
+
+Consumed keys (`title`, `author`, `date`, `margin`, `fontsize`, `font`,
+`page_numbers`) are stripped from the frontmatter before pandoc reads it, to
+avoid double-emission in the title block. `toc` and `numbersections` are
+preserved so pandoc reads them directly.
+
+Unrecognized frontmatter keys emit a warning to stderr but do not abort
+rendering.
 
 ### Author resolution
 

--- a/bin/md2pdf
+++ b/bin/md2pdf
@@ -27,10 +27,12 @@
 #   ./bin/md2pdf --install-deps-all
 
 require "digest"
+require "date"
 require "fileutils"
 require "json"
 require "optparse"
 require "tmpdir"
+require "yaml"
 
 # ---------------------------------------------------------------------------
 # Mode registry
@@ -58,6 +60,22 @@ DEFAULTS = {
 
 MERMAID_NPM_PACKAGE = "@mermaid-js/mermaid-cli"
 MERMAID_BIN = "mmdc"
+
+# Frontmatter keys md2pdf understands (canonical names).
+FRONTMATTER_RECOGNIZED = %w[title author date margin fontsize font page_numbers toc numbersections].freeze
+
+# Aliased frontmatter keys mapped to their canonical name.
+FRONTMATTER_ALIASES = {
+  "font_size" => "fontsize",
+  "page-numbers" => "page_numbers",
+  "pageNumbers" => "page_numbers",
+  "number_sections" => "numbersections",
+  "number_section" => "numbersections",
+}.freeze
+
+# Keys md2pdf consumes itself (passed to renderers via flags), so they are stripped
+# from the frontmatter before pandoc reads it to avoid double-emission.
+FRONTMATTER_CONSUMED = %w[title author date margin fontsize font page_numbers].freeze
 
 # --- Mermaid preprocessor ---
 #
@@ -193,73 +211,62 @@ module RenderHelpers
     number_sections?(content)
   end
 
-  def resolve_toc(content, override, default)
-    return override unless override.nil?
-
-    frontmatter_bool(content, "toc") { default }
-  end
-
-  def normalize_number_sections_frontmatter(content)
-    content.sub(/\A((?:\uFEFF)?---[ \t]*\r?\n.*?\r?\n---[ \t]*(?:\r?\n|\z))/m) do |frontmatter|
-      frontmatter.gsub(/^([ \t]*)number_sections([ \t]*:)/, "\\1numbersections\\2")
-    end
-  end
-
-  def remove_frontmatter_key(content, key)
-    content.sub(/\A((?:\uFEFF)?---[ \t]*\r?\n.*?\r?\n---[ \t]*(?:\r?\n|\z))/m) do |frontmatter|
-      remove_yaml_key(frontmatter, key)
-    end
-  end
-
-  def frontmatter_bool(content, key)
+  # Parse the frontmatter block and return [options_hash, unknown_keys].
+  # options_hash uses symbol keys with canonical names.
+  def frontmatter_options(content)
     body = frontmatter_body(content)
-    return yield unless body
+    return [{}, []] unless body
 
-    body.each_line do |line|
-      next unless (match = line.match(/^[ \t]*#{Regexp.escape(key)}[ \t]*:[ \t]*(?<value>[^#\r\n]*)/))
+    data = YAML.safe_load(body, permitted_classes: [Date, Time], aliases: false)
+    return [{}, []] unless data.is_a?(Hash)
 
-      value = match[:value].strip.downcase
-      return true if %w[true yes on 1].include?(value)
-      return false if %w[false no off 0].include?(value)
-    end
+    options = {}
+    unknown = []
+    data.each do |key, value|
+      key = key.to_s
+      canonical = FRONTMATTER_ALIASES[key] || key
 
-    yield
-  end
-
-  def frontmatter_string(content, key)
-    body = frontmatter_body(content)
-    return nil unless body
-
-    body.each_line do |line|
-      next unless (match = line.match(/^[ \t]*#{Regexp.escape(key)}[ \t]*:[ \t]*(?<value>[^\r\n]*)/))
-
-      value = match[:value].strip
-      next if value.empty?
-
-      if (quoted = value.match(/\A"(?<inner>.*)"\z/) || value.match(/\A'(?<inner>.*)'\z/))
-        return quoted[:inner]
+      unless FRONTMATTER_RECOGNIZED.include?(canonical)
+        unknown << key
+        next
       end
 
-      value = value.sub(/[ \t]+#.*\z/, "").rstrip
-      return value unless value.empty?
+      case canonical
+      when "page_numbers", "toc", "numbersections"
+        bool = parse_frontmatter_bool(value)
+        options[canonical.to_sym] = bool unless bool.nil?
+      else
+        next if value.nil? || value.is_a?(Array) || value.is_a?(Hash)
+        options[canonical.to_sym] = value.to_s
+      end
     end
-
-    nil
+    [options, unknown]
+  rescue Psych::Exception
+    [{}, []]
   end
 
-  def remove_yaml_key(frontmatter, key)
-    lines = frontmatter.lines
+  # Rewrite the leading frontmatter block: drop lines for keys md2pdf consumes,
+  # and normalize remaining alias keys (number_sections -> numbersections) so
+  # pandoc reads its expected metadata names.
+  def prune_frontmatter(content)
+    content.sub(/\A(?<pre>(?:﻿)?---[ \t]*\r?\n)(?<body>.*?)(?<post>\r?\n---[ \t]*(?:\r?\n|\z))/m) do
+      pre = Regexp.last_match(:pre)
+      body = Regexp.last_match(:body)
+      post = Regexp.last_match(:post)
+
+      kept = prune_consumed_frontmatter_lines(body)
+      kept = kept.gsub(/^(?:number_sections|number_section)([ \t]*:)/, "numbersections\\1")
+
+      "#{pre}#{kept}#{post}"
+    end
+  end
+
+  def prune_consumed_frontmatter_lines(body)
     output = []
     skipping = false
     key_indent = 0
 
-    lines.each_with_index do |line, index|
-      if index.zero? || line.match?(/\A---[ \t]*(?:\r?\n|\z)/)
-        output << line
-        skipping = false
-        next
-      end
-
+    body.each_line do |line|
       if skipping
         indent = line[/\A[ \t]*/].length
         next if line.strip.empty? || indent > key_indent || (indent == key_indent && line.lstrip.start_with?("-"))
@@ -267,10 +274,13 @@ module RenderHelpers
         skipping = false
       end
 
-      if (match = line.match(/\A(?<indent>[ \t]*)#{Regexp.escape(key)}[ \t]*:/))
-        key_indent = match[:indent].length
-        skipping = true
-        next
+      if (m = line.match(/\A(?<key>[A-Za-z][A-Za-z0-9_-]*)[ \t]*:/))
+        canonical = FRONTMATTER_ALIASES[m[:key]] || m[:key]
+        if FRONTMATTER_CONSUMED.include?(canonical)
+          key_indent = 0
+          skipping = true
+          next
+        end
       end
 
       output << line
@@ -279,11 +289,20 @@ module RenderHelpers
     output.join
   end
 
+  def parse_frontmatter_bool(value)
+    return value if value == true || value == false
+
+    v = value.to_s.strip.downcase
+    return true if %w[true yes on 1].include?(v)
+    return false if %w[false no off 0].include?(v)
+    nil
+  end
+
   def frontmatter_controls_numbering?(content)
     body = frontmatter_body(content)
     return false unless body
 
-    body.each_line.any? { |line| line.match?(/^[ \t]*(numbersections|number_section|number_sections)[ \t]*:/) }
+    body.each_line.any? { |line| line.match?(/^(numbersections|number_section|number_sections)[ \t]*:/) }
   end
 
   def frontmatter_body(content)
@@ -310,9 +329,7 @@ PANDOC_RENDER = ->(ctx) do
 
   # Preprocess: title block + unicode normalization
   content = "% #{ctx[:title]}\n% #{ctx[:author] || ""}\n% #{ctx[:date]}\n\n"
-  source_content = File.read(ctx[:input], encoding: "utf-8")
-  source_content = RenderHelpers.remove_frontmatter_key(source_content, "author") if ctx[:author_overrides_frontmatter]
-  content << RenderHelpers.normalize_number_sections_frontmatter(source_content)
+  content << RenderHelpers.prune_frontmatter(File.read(ctx[:input], encoding: "utf-8"))
   LATEX_UNICODE.each { |k, v| content.gsub!(k, v) }
   PDFLATEX_EXTRA.each { |k, v| content.gsub!(k, v) } if engine == "pdflatex"
   tmp_md = RenderHelpers.tmpfile(ctx, "combined.md", content)
@@ -532,14 +549,13 @@ MODES = {
 class Md2Pdf
   def initialize(argv)
     @mode = DEFAULTS[:mode]
-    @font_family = DEFAULTS[:font_family]
-    @margin = DEFAULTS[:margin]
-    @fontsize = DEFAULTS[:fontsize]
+    @font_family = nil
+    @margin = nil
+    @fontsize = nil
     @toc = nil
     @number_sections = nil
-    @page_numbers = DEFAULTS[:page_numbers]
+    @page_numbers = nil
     @mermaid = true
-    @font_explicit = false
     @title = nil
     @author = nil
     @author_explicit = false
@@ -576,7 +592,7 @@ class Md2Pdf
       opts.on("-a", "--author AUTHOR", "Author line (default: frontmatter author, then git config user.name)") { |v| @author = v; @author_explicit = true }
       opts.on("--no-author", "Suppress author line entirely (overrides frontmatter and git fallback)") { @no_author = true }
       opts.on("-o PATH", "--output PATH", "Output PDF path (required when passing multiple inputs)") { |v| @output_file = v }
-      opts.on("--font FONT", "Body font") { |v| @font_family = v; @font_explicit = true }
+      opts.on("--font FONT", "Body font") { |v| @font_family = v }
       opts.on("-m MARGIN", "Page margin (default: #{DEFAULTS[:margin]})") { |v| @margin = v }
       opts.on("-s SIZE", "Font size (default: #{DEFAULTS[:fontsize]})") { |v| @fontsize = v }
       opts.on("--[no-]toc", "Table of contents (default: on unless frontmatter sets toc)") { |v| @toc = v }
@@ -661,28 +677,36 @@ class Md2Pdf
       abort "Dependencies missing for mode '#{@mode}'. Run: #{$PROGRAM_NAME} --mode #{@mode} --install-deps"
     end
 
-    ensure_font(cfg[:engine]) if cfg[:font_check]
-
     binary = resolve_binary(cfg[:binary])
     resolved = resolve_output
     FileUtils.mkdir_p(File.dirname(resolved))
     tmpdir = new_temp_dir
     effective_input = prepare_input(tmpdir)
     source_content = File.read(effective_input, encoding: "utf-8")
+    fm_options, unknown_keys = RenderHelpers.frontmatter_options(source_content)
+    unknown_keys.each { |k| warn "warning: unrecognized frontmatter key: #{k}" }
+    warn_unmapped_frontmatter_options(fm_options)
+
+    resolved_font = @font_family || fm_options[:font] || DEFAULTS[:font_family]
+    ensure_font(cfg[:engine], resolved_font) if cfg[:font_check]
+
     input_path = preprocess_mermaid(source_content, tmpdir) || effective_input
 
     ctx = {
       binary: binary, input: input_path, output: resolved, tmpdir: tmpdir,
       source_dir: File.dirname(File.expand_path(@input_files.first)),
-      title: detect_title, author: resolve_author(source_content), date: latex_date,
-      margin: @margin, fontsize: @fontsize, font: @font_family,
-      toc: RenderHelpers.resolve_toc(source_content, @toc, DEFAULTS[:toc]),
+      title: @title || fm_options[:title] || detect_title_from_source,
+      author: resolve_author(fm_options),
+      date: fm_options[:date] || latex_date,
+      margin: @margin || fm_options[:margin] || DEFAULTS[:margin],
+      fontsize: @fontsize || fm_options[:fontsize] || DEFAULTS[:fontsize],
+      font: resolved_font,
+      toc: !@toc.nil? ? @toc : (fm_options.key?(:toc) ? fm_options[:toc] : DEFAULTS[:toc]),
       toc_override: @toc,
-      page_numbers: @page_numbers,
+      page_numbers: !@page_numbers.nil? ? @page_numbers : (fm_options.key?(:page_numbers) ? fm_options[:page_numbers] : DEFAULTS[:page_numbers]),
       engine: cfg[:engine],
       number_sections: RenderHelpers.resolve_number_sections(source_content, @number_sections),
       number_sections_override: @number_sections,
-      author_overrides_frontmatter: @author_explicit || @no_author,
       resource_path: build_resource_path,
     }
 
@@ -774,10 +798,22 @@ class Md2Pdf
     supports = cfg[:supports]
     @warnings << "mode #{@mode} ignores -t/--title" if @title && !supports.include?(:title)
     @warnings << "mode #{@mode} ignores -a/--author" if @author_explicit && !supports.include?(:author)
-    @warnings << "mode #{@mode} ignores -m/--margin" if @margin != DEFAULTS[:margin] && !supports.include?(:margin)
-    @warnings << "mode #{@mode} ignores -s/--size" if @fontsize != DEFAULTS[:fontsize] && !supports.include?(:fontsize)
-    @warnings << "mode #{@mode} does not support arbitrary system font selection" if @font_explicit && !supports.include?(:font)
-    @warnings << "mode #{@mode} does not support auto-generated TOC" if !@toc.nil? && @toc != DEFAULTS[:toc] && !supports.include?(:toc)
+    @warnings << "mode #{@mode} ignores -m/--margin" if @margin && !supports.include?(:margin)
+    @warnings << "mode #{@mode} ignores -s/--size" if @fontsize && !supports.include?(:fontsize)
+    @warnings << "mode #{@mode} does not support arbitrary system font selection" if @font_family && !supports.include?(:font)
+    @warnings << "mode #{@mode} does not support auto-generated TOC" if !@toc.nil? && !supports.include?(:toc)
+  end
+
+  def warn_unmapped_frontmatter_options(options)
+    supports = cfg[:supports]
+    warn "warning: mode #{@mode} ignores frontmatter title" if !@title && options.key?(:title) && !supports.include?(:title)
+    warn "warning: mode #{@mode} ignores frontmatter author" if !@author && options.key?(:author) && !supports.include?(:author)
+    warn "warning: mode #{@mode} ignores frontmatter margin" if !@margin && options.key?(:margin) && !supports.include?(:margin)
+    warn "warning: mode #{@mode} ignores frontmatter fontsize" if !@fontsize && options.key?(:fontsize) && !supports.include?(:fontsize)
+    if !@font_family && options.key?(:font) && !supports.include?(:font)
+      warn "warning: mode #{@mode} does not support arbitrary system font selection"
+    end
+    warn "warning: mode #{@mode} does not support auto-generated TOC" if @toc.nil? && options.key?(:toc) && !supports.include?(:toc)
   end
 
   def flush_warnings
@@ -786,8 +822,7 @@ class Md2Pdf
 
   # --- Helpers ---
 
-  def detect_title
-    return @title if @title
+  def detect_title_from_source
     first = @input_files.first
     File.foreach(first) do |line|
       return line.sub(/^#\s+/, "").strip if line.start_with?("# ")
@@ -804,12 +839,10 @@ class Md2Pdf
   #   git config user.name -> that (run from input file's directory)
   #   NAME, MAILNAME       -> first non-empty
   #   else                 -> nil
-  def resolve_author(source_content)
+  def resolve_author(fm_options)
     return nil if @no_author
     return @author if @author
-
-    fm = RenderHelpers.frontmatter_string(source_content, "author")
-    return fm if fm
+    return fm_options[:author] if fm_options[:author]
 
     git_env = env_value("GIT_AUTHOR_NAME") || env_value("GIT_COMMITTER_NAME")
     return git_env if git_env
@@ -887,21 +920,21 @@ class Md2Pdf
     system(env, *args, **opts, exception: true)
   end
 
-  def ensure_font(engine)
+  def ensure_font(engine, font)
     tmpdir = Dir.mktmpdir("md2pdf-font-")
     tex = File.join(tmpdir, "check.tex")
-    File.write(tex, "\\documentclass{article}\n\\usepackage{fontspec}\n\\setmainfont{#{@font_family}}\n\\begin{document}\nfont check\n\\end{document}\n")
+    File.write(tex, "\\documentclass{article}\n\\usepackage{fontspec}\n\\setmainfont{#{font}}\n\\begin{document}\nfont check\n\\end{document}\n")
     success = system(engine, "-interaction=nonstopmode", "-halt-on-error",
                      "-output-directory", tmpdir, tex, out: File::NULL, err: File::NULL)
     FileUtils.rm_rf(tmpdir)
     return if success
-    if @font_family == DEFAULTS[:font_family] && (brew = brew_cmd)
-      warn "Missing font '#{@font_family}'. Installing via: brew install --cask #{DEFAULTS[:font_cask]}"
+    if font == DEFAULTS[:font_family] && (brew = brew_cmd)
+      warn "Missing font '#{font}'. Installing via: brew install --cask #{DEFAULTS[:font_cask]}"
       if system(brew, "install", "--cask", DEFAULTS[:font_cask])
         return
       end
     end
-    abort "#{@font_family} not available to #{engine}. Install the font on your system, then rerun."
+    abort "#{font} not available to #{engine}. Install the font on your system, then rerun."
   end
 
   def ensure_npm_package(package)

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -150,3 +150,35 @@
   a named group (e.g., `(?<body>...)`), unnamed groups stop being indexable via
   `m[1]`/`m[3]` and only the named ones populate. Fix: name *all* groups consistently
   in the same pattern.
+
+## AG-6 Review Fixes: Frontmatter parser regressions
+
+- [x] Restate goal + acceptance criteria
+  - Goal: Add failing coverage for the three review findings, then fix frontmatter parsing and unsupported-option warnings.
+  - Acceptance: quoted `#` scalar values remain intact; nested YAML keys are not treated as top-level md2pdf options or stripped; frontmatter options unsupported by a selected renderer warn before rendering.
+- [x] Locate existing implementation / patterns
+  - `RenderHelpers.frontmatter_options` owns option extraction; `prune_frontmatter` owns metadata stripping; `warn_unmapped_options` only sees CLI state before render.
+- [x] Add regression tests for each reviewed issue and confirm they fail
+  - `bats tests/frontmatter_options.bats` failed on the three new tests before implementation.
+- [x] Implement smallest safe parser/warning fix
+  - Use `YAML.safe_load` for top-level option extraction; constrain pruning to top-level consumed keys only; emit unsupported frontmatter warnings after parsing.
+- [x] Run focused and full verification
+- [x] Summarize changes + verification story
+- [x] Record lessons (if any)
+
+### Working Notes
+
+- The current parser is regex/line based; reviewed failures are in scalar comment handling, top-level key detection, and warning timing.
+
+### Results
+
+- Added regression tests for quoted hash scalars, nested YAML metadata, nested `numbersections`, and unsupported frontmatter `font` under `pandoc-pdflatex`.
+- Replaced regex value extraction with YAML parsing for frontmatter options and kept nested metadata intact during pruning.
+- Unsupported frontmatter options now warn during render after frontmatter is available.
+- Verification:
+  - `ruby -c bin/md2pdf` — Syntax OK.
+  - `bats tests/frontmatter_options.bats tests/section_numbering.bats` — 33 tests passed.
+  - `bats tests/author_resolution.bats tests/frontmatter_options.bats tests/section_numbering.bats` — 50 tests passed after rebase.
+  - `bats tests/` — 143 tests passed after rebase.
+  - `git diff --check origin/master...HEAD` — passed.
+- Lessons: no new correction; these regressions were covered before fixing as requested.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -133,3 +133,20 @@
 - `make test` passed: 106 tests.
 - `git diff --check` passed.
 - `./bin/md2pdf --help` shows `-a, --author AUTHOR`.
+
+## AG-6 (Linear): Frontmatter-driven per-doc options
+
+- [x] Add `frontmatter_options` parser returning `(options_hash, unknown_keys)`
+- [x] Add `prune_frontmatter` to strip consumed keys + normalize aliases
+- [x] Wire CLI > frontmatter > default precedence in `Md2Pdf#render`
+- [x] Strip `title`, `author`, `date`, `margin`, `fontsize`, `font`, `page_numbers` from frontmatter passed to pandoc
+- [x] Warn on unrecognized frontmatter keys
+- [x] Tests for title, author, margin, fontsize, font, page_numbers, date, aliases, unknown-key warning
+- [x] README updated with recognized keys, aliases, and precedence
+
+### Lessons
+
+- Ruby `Regexp` mixes named and unnamed capture groups badly — when a pattern contains
+  a named group (e.g., `(?<body>...)`), unnamed groups stop being indexable via
+  `m[1]`/`m[3]` and only the named ones populate. Fix: name *all* groups consistently
+  in the same pattern.

--- a/tests/author_resolution.bats
+++ b/tests/author_resolution.bats
@@ -273,7 +273,8 @@ clear_author_env() {
   grep -q "^% $" "$MD2PDF_PANDOC_INPUT_LOG"
   ! grep -q "Frontmatter One" "$MD2PDF_PANDOC_INPUT_LOG"
   ! grep -q "Frontmatter Two" "$MD2PDF_PANDOC_INPUT_LOG"
-  grep -q "title: Frontmatter Title" "$MD2PDF_PANDOC_INPUT_LOG"
+  grep -q "^% Frontmatter Title$" "$MD2PDF_PANDOC_INPUT_LOG"
+  ! grep -q "title: Frontmatter Title" "$MD2PDF_PANDOC_INPUT_LOG"
   grep -q "toc: true" "$MD2PDF_PANDOC_INPUT_LOG"
 }
 

--- a/tests/frontmatter_options.bats
+++ b/tests/frontmatter_options.bats
@@ -1,0 +1,246 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup_fake_pandoc() {
+  mkdir -p "$TEST_TEMP_DIR/fake-bin"
+
+  cat > "$TEST_TEMP_DIR/fake-bin/xelatex" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+
+  cat > "$TEST_TEMP_DIR/fake-bin/pandoc" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$MD2PDF_PANDOC_ARGS_LOG"
+cp "$1" "$MD2PDF_PANDOC_INPUT_LOG"
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-o" ]; then
+    shift
+    touch "$1"
+    exit 0
+  fi
+  shift
+done
+exit 0
+SH
+
+  chmod +x "$TEST_TEMP_DIR/fake-bin/pandoc" "$TEST_TEMP_DIR/fake-bin/xelatex"
+  export PATH="$TEST_TEMP_DIR/fake-bin:$PATH"
+  export MD2PDF_PANDOC_ARGS_LOG="$TEST_TEMP_DIR/pandoc-args.txt"
+  export MD2PDF_PANDOC_INPUT_LOG="$TEST_TEMP_DIR/pandoc-input.md"
+}
+
+write_doc() {
+  local path="$1"
+  shift
+  printf '%s\n' "$@" > "$path"
+}
+
+@test "frontmatter title is used as title block" {
+  setup_fake_pandoc
+  local input="$TEST_TEMP_DIR/fm-title.md"
+  write_doc "$input" "---" "title: Frontmatter Title" "---" "" "# H1 Heading" "" "Body"
+
+  run "$MD2PDF" "$input" "$TEST_TEMP_DIR/out.pdf"
+
+  [ "$status" -eq 0 ]
+  grep -q "^% Frontmatter Title$" "$MD2PDF_PANDOC_INPUT_LOG"
+  ! grep -q "^% H1 Heading$" "$MD2PDF_PANDOC_INPUT_LOG"
+}
+
+@test "CLI -t overrides frontmatter title" {
+  setup_fake_pandoc
+  local input="$TEST_TEMP_DIR/fm-title.md"
+  write_doc "$input" "---" "title: Frontmatter Title" "---" "" "# H1 Heading" "" "Body"
+
+  run "$MD2PDF" -t "CLI Title" "$input" "$TEST_TEMP_DIR/out.pdf"
+
+  [ "$status" -eq 0 ]
+  grep -q "^% CLI Title$" "$MD2PDF_PANDOC_INPUT_LOG"
+  ! grep -q "^% Frontmatter Title$" "$MD2PDF_PANDOC_INPUT_LOG"
+}
+
+@test "frontmatter author is used in title block" {
+  setup_fake_pandoc
+  local input="$TEST_TEMP_DIR/fm-author.md"
+  write_doc "$input" "---" "author: Jane Doe" "---" "" "# Title" "" "Body"
+
+  run "$MD2PDF" "$input" "$TEST_TEMP_DIR/out.pdf"
+
+  [ "$status" -eq 0 ]
+  grep -q "^% Jane Doe$" "$MD2PDF_PANDOC_INPUT_LOG"
+}
+
+@test "CLI -a overrides frontmatter author" {
+  setup_fake_pandoc
+  local input="$TEST_TEMP_DIR/fm-author.md"
+  write_doc "$input" "---" "author: Jane Doe" "---" "" "# Title" "" "Body"
+
+  run "$MD2PDF" -a "John Smith" "$input" "$TEST_TEMP_DIR/out.pdf"
+
+  [ "$status" -eq 0 ]
+  grep -q "^% John Smith$" "$MD2PDF_PANDOC_INPUT_LOG"
+  ! grep -q "^% Jane Doe$" "$MD2PDF_PANDOC_INPUT_LOG"
+}
+
+@test "frontmatter margin produces matching geometry arg" {
+  setup_fake_pandoc
+  local input="$TEST_TEMP_DIR/fm-margin.md"
+  write_doc "$input" "---" "margin: 0.5in" "---" "" "# Title" "" "Body"
+
+  run "$MD2PDF" "$input" "$TEST_TEMP_DIR/out.pdf"
+
+  [ "$status" -eq 0 ]
+  grep -qx -- "geometry:margin=0.5in" "$MD2PDF_PANDOC_ARGS_LOG"
+}
+
+@test "CLI -m overrides frontmatter margin" {
+  setup_fake_pandoc
+  local input="$TEST_TEMP_DIR/fm-margin.md"
+  write_doc "$input" "---" "margin: 0.5in" "---" "" "# Title" "" "Body"
+
+  run "$MD2PDF" -m "0.75in" "$input" "$TEST_TEMP_DIR/out.pdf"
+
+  [ "$status" -eq 0 ]
+  grep -qx -- "geometry:margin=0.75in" "$MD2PDF_PANDOC_ARGS_LOG"
+}
+
+@test "frontmatter fontsize produces matching fontsize arg" {
+  setup_fake_pandoc
+  local input="$TEST_TEMP_DIR/fm-fontsize.md"
+  write_doc "$input" "---" "fontsize: 13pt" "---" "" "# Title" "" "Body"
+
+  run "$MD2PDF" "$input" "$TEST_TEMP_DIR/out.pdf"
+
+  [ "$status" -eq 0 ]
+  grep -qx -- "fontsize:13pt" "$MD2PDF_PANDOC_ARGS_LOG"
+}
+
+@test "frontmatter font_size alias normalizes to fontsize" {
+  setup_fake_pandoc
+  local input="$TEST_TEMP_DIR/fm-fontsize-alias.md"
+  write_doc "$input" "---" "font_size: 13pt" "---" "" "# Title" "" "Body"
+
+  run "$MD2PDF" "$input" "$TEST_TEMP_DIR/out.pdf"
+
+  [ "$status" -eq 0 ]
+  grep -qx -- "fontsize:13pt" "$MD2PDF_PANDOC_ARGS_LOG"
+}
+
+@test "frontmatter font produces matching mainfont arg" {
+  setup_fake_pandoc
+  local input="$TEST_TEMP_DIR/fm-font.md"
+  write_doc "$input" "---" "font: Helvetica" "---" "" "# Title" "" "Body"
+
+  run "$MD2PDF" "$input" "$TEST_TEMP_DIR/out.pdf"
+
+  [ "$status" -eq 0 ]
+  grep -qx -- "mainfont:Helvetica" "$MD2PDF_PANDOC_ARGS_LOG"
+}
+
+@test "frontmatter page_numbers false disables page numbers" {
+  setup_fake_pandoc
+  local input="$TEST_TEMP_DIR/fm-pages.md"
+  write_doc "$input" "---" "page_numbers: false" "---" "" "# Title" "" "Body"
+
+  run "$MD2PDF" "$input" "$TEST_TEMP_DIR/out.pdf"
+
+  [ "$status" -eq 0 ]
+  grep -qx -- "pagestyle:empty" "$MD2PDF_PANDOC_ARGS_LOG"
+}
+
+@test "frontmatter page-numbers alias is honored" {
+  setup_fake_pandoc
+  local input="$TEST_TEMP_DIR/fm-pages-alias.md"
+  write_doc "$input" "---" "page-numbers: false" "---" "" "# Title" "" "Body"
+
+  run "$MD2PDF" "$input" "$TEST_TEMP_DIR/out.pdf"
+
+  [ "$status" -eq 0 ]
+  grep -qx -- "pagestyle:empty" "$MD2PDF_PANDOC_ARGS_LOG"
+}
+
+@test "CLI --page-numbers overrides frontmatter page_numbers false" {
+  setup_fake_pandoc
+  local input="$TEST_TEMP_DIR/fm-pages.md"
+  write_doc "$input" "---" "page_numbers: false" "---" "" "# Title" "" "Body"
+
+  run "$MD2PDF" --page-numbers "$input" "$TEST_TEMP_DIR/out.pdf"
+
+  [ "$status" -eq 0 ]
+  grep -qx -- "pagestyle:plain" "$MD2PDF_PANDOC_ARGS_LOG"
+}
+
+@test "frontmatter date appears in title block" {
+  setup_fake_pandoc
+  local input="$TEST_TEMP_DIR/fm-date.md"
+  write_doc "$input" "---" "date: January 1, 2026" "---" "" "# Title" "" "Body"
+
+  run "$MD2PDF" "$input" "$TEST_TEMP_DIR/out.pdf"
+
+  [ "$status" -eq 0 ]
+  grep -q "^% January 1, 2026$" "$MD2PDF_PANDOC_INPUT_LOG"
+}
+
+@test "consumed frontmatter keys are stripped from pandoc input" {
+  setup_fake_pandoc
+  local input="$TEST_TEMP_DIR/fm-strip.md"
+  write_doc "$input" "---" "title: T" "author: A" "margin: 0.5in" "fontsize: 9pt" "font: F" "page_numbers: false" "date: D" "---" "" "Body"
+
+  run "$MD2PDF" "$input" "$TEST_TEMP_DIR/out.pdf"
+
+  [ "$status" -eq 0 ]
+  ! grep -q "^title:" "$MD2PDF_PANDOC_INPUT_LOG"
+  ! grep -q "^author:" "$MD2PDF_PANDOC_INPUT_LOG"
+  ! grep -q "^margin:" "$MD2PDF_PANDOC_INPUT_LOG"
+  ! grep -q "^fontsize:" "$MD2PDF_PANDOC_INPUT_LOG"
+  ! grep -q "^font:" "$MD2PDF_PANDOC_INPUT_LOG"
+  ! grep -q "^page_numbers:" "$MD2PDF_PANDOC_INPUT_LOG"
+  ! grep -q "^date:" "$MD2PDF_PANDOC_INPUT_LOG"
+}
+
+@test "toc and numbersections survive frontmatter pruning" {
+  setup_fake_pandoc
+  local input="$TEST_TEMP_DIR/fm-survive.md"
+  write_doc "$input" "---" "title: T" "toc: true" "numbersections: true" "---" "" "# Title" "" "## Intro"
+
+  run "$MD2PDF" "$input" "$TEST_TEMP_DIR/out.pdf"
+
+  [ "$status" -eq 0 ]
+  grep -qx -- "toc: true" "$MD2PDF_PANDOC_INPUT_LOG"
+  grep -qx -- "numbersections: true" "$MD2PDF_PANDOC_INPUT_LOG"
+}
+
+@test "unknown frontmatter key emits warning to stderr" {
+  setup_fake_pandoc
+  local input="$TEST_TEMP_DIR/fm-unknown.md"
+  write_doc "$input" "---" "title: T" "bogus_key: value" "---" "" "Body"
+
+  run "$MD2PDF" "$input" "$TEST_TEMP_DIR/out.pdf"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"warning: unrecognized frontmatter key: bogus_key"* ]]
+}
+
+@test "unknown frontmatter key does not abort rendering" {
+  setup_fake_pandoc
+  local input="$TEST_TEMP_DIR/fm-unknown-render.md"
+  write_doc "$input" "---" "bogus: x" "---" "" "Body"
+
+  run "$MD2PDF" "$input" "$TEST_TEMP_DIR/out.pdf"
+
+  [ "$status" -eq 0 ]
+  [ -f "$TEST_TEMP_DIR/out.pdf" ]
+}
+
+@test "quoted frontmatter string values are unwrapped" {
+  setup_fake_pandoc
+  local input="$TEST_TEMP_DIR/fm-quoted.md"
+  write_doc "$input" "---" 'title: "Quoted Title"' "---" "" "Body"
+
+  run "$MD2PDF" "$input" "$TEST_TEMP_DIR/out.pdf"
+
+  [ "$status" -eq 0 ]
+  grep -q "^% Quoted Title$" "$MD2PDF_PANDOC_INPUT_LOG"
+}

--- a/tests/frontmatter_options.bats
+++ b/tests/frontmatter_options.bats
@@ -10,6 +10,11 @@ setup_fake_pandoc() {
 exit 0
 SH
 
+  cat > "$TEST_TEMP_DIR/fake-bin/pdflatex" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+
   cat > "$TEST_TEMP_DIR/fake-bin/pandoc" <<'SH'
 #!/usr/bin/env bash
 printf '%s\n' "$@" > "$MD2PDF_PANDOC_ARGS_LOG"
@@ -25,7 +30,7 @@ done
 exit 0
 SH
 
-  chmod +x "$TEST_TEMP_DIR/fake-bin/pandoc" "$TEST_TEMP_DIR/fake-bin/xelatex"
+  chmod +x "$TEST_TEMP_DIR/fake-bin/pandoc" "$TEST_TEMP_DIR/fake-bin/xelatex" "$TEST_TEMP_DIR/fake-bin/pdflatex"
   export PATH="$TEST_TEMP_DIR/fake-bin:$PATH"
   export MD2PDF_PANDOC_ARGS_LOG="$TEST_TEMP_DIR/pandoc-args.txt"
   export MD2PDF_PANDOC_INPUT_LOG="$TEST_TEMP_DIR/pandoc-input.md"
@@ -243,4 +248,40 @@ write_doc() {
 
   [ "$status" -eq 0 ]
   grep -q "^% Quoted Title$" "$MD2PDF_PANDOC_INPUT_LOG"
+}
+
+@test "quoted frontmatter values may contain hash characters" {
+  setup_fake_pandoc
+  local input="$TEST_TEMP_DIR/fm-quoted-hash.md"
+  write_doc "$input" "---" 'title: "C# Guide"' "---" "" "# H1 Heading" "" "Body"
+
+  run "$MD2PDF" "$input" "$TEST_TEMP_DIR/out.pdf"
+
+  [ "$status" -eq 0 ]
+  grep -q "^% C# Guide$" "$MD2PDF_PANDOC_INPUT_LOG"
+  ! grep -q '^% "C$' "$MD2PDF_PANDOC_INPUT_LOG"
+}
+
+@test "nested frontmatter keys are not treated as md2pdf options" {
+  setup_fake_pandoc
+  local input="$TEST_TEMP_DIR/fm-nested.md"
+  write_doc "$input" "---" "project:" "  title: Nested Title" "---" "" "# H1 Heading" "" "Body"
+
+  run "$MD2PDF" "$input" "$TEST_TEMP_DIR/out.pdf"
+
+  [ "$status" -eq 0 ]
+  grep -q "^% H1 Heading$" "$MD2PDF_PANDOC_INPUT_LOG"
+  ! grep -q "^% Nested Title$" "$MD2PDF_PANDOC_INPUT_LOG"
+  grep -qx -- "  title: Nested Title" "$MD2PDF_PANDOC_INPUT_LOG"
+}
+
+@test "frontmatter options unsupported by selected mode emit warnings" {
+  setup_fake_pandoc
+  local input="$TEST_TEMP_DIR/fm-unsupported-font.md"
+  write_doc "$input" "---" "font: Helvetica" "---" "" "# Title" "" "Body"
+
+  run "$MD2PDF" --mode pandoc-pdflatex "$input" "$TEST_TEMP_DIR/out.pdf"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"warning: mode pandoc-pdflatex does not support arbitrary system font selection"* ]]
 }

--- a/tests/section_numbering.bats
+++ b/tests/section_numbering.bats
@@ -91,6 +91,18 @@ assert_arg_absent() {
   ! grep -qx -- "number_sections: true" "$MD2PDF_PANDOC_INPUT_LOG"
 }
 
+@test "nested frontmatter numbersections does not disable automatic section numbering" {
+  setup_fake_pandoc
+  local input="$TEST_TEMP_DIR/nested-numbersections.md"
+  write_doc "$input" "---" "project:" "  numbersections: false" "---" "" "# Title" "" "## Introduction"
+
+  run "$MD2PDF" "$input" "$TEST_TEMP_DIR/out.pdf"
+
+  [ "$status" -eq 0 ]
+  assert_arg_present "--number-sections"
+  grep -qx -- "  numbersections: false" "$MD2PDF_PANDOC_INPUT_LOG"
+}
+
 @test "--no-number-sections disables default automatic section numbering" {
   setup_fake_pandoc
   local input="$TEST_TEMP_DIR/no-number-sections.md"


### PR DESCRIPTION
## Summary
Adds frontmatter-driven per-document options for title, author, date, margin, font size, font, page numbers, TOC, and section numbering with CLI > frontmatter > default precedence.
Also integrates author resolution with `--author`/`--no-author`, git/env fallback, consumed-metadata pruning, and warnings for unknown or unsupported frontmatter keys.
Updates README and tests for aliases, nested metadata, quoted hash values, unsupported options, author precedence, and section numbering.

## Verification
- `ruby -c bin/md2pdf`
- `git diff --check origin/master...HEAD`
- `bats tests/` (143 tests)