### PR TITLE
CI workflow + auto-merge Homebrew tap formula bumps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - "**"
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: bats tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y bats pandoc
+
+      - name: Run tests
+        run: make test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,7 @@ jobs:
           (cd homebrew-tap && git --no-pager diff -- Formula/md2pdf.rb)
 
       - name: Open pull request
+        id: cpr
         uses: peter-evans/create-pull-request@v6
         with:
           path: homebrew-tap
@@ -75,3 +76,12 @@ jobs:
 
             - url: ${{ steps.meta.outputs.tarball_url }}
             - sha256: `${{ steps.meta.outputs.sha256 }}`
+
+      - name: Squash-merge the formula bump
+        if: steps.cpr.outputs.pull-request-number != ''
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          gh pr merge "${{ steps.cpr.outputs.pull-request-number }}" \
+            --repo alexg0/homebrew-tap \
+            --squash --delete-branch


### PR DESCRIPTION
## Summary
- Add `.github/workflows/ci.yml` running `make test` (bats + pandoc) on every push and PR, with a concurrency group that cancels in-progress runs on the same ref.
- Update `.github/workflows/release.yml` to squash-merge and delete-branch the auto-opened formula bump PR against `alexg0/homebrew-tap`, so the tap formula's sha256 is always the real one (the seeded zero placeholder broke `brew install` on v0.1.0 until the PR was merged by hand).

## Test plan
- [x] `make test` — 143 bats tests pass locally
- [ ] CI green on this PR
- [ ] Next tag push opens, merges, and deletes the tap PR end-to-end