### PR TITLE
Fix YAML crash on fully-consumed frontmatter, add --prevent-widows, dev shim

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# AGENTS.md — md2pdf project notes
+
+## Architecture in one paragraph
+
+`bin/md2pdf` is a single self-contained Ruby script. For pandoc modes, `PANDOC_RENDER` (`bin/md2pdf:318`) builds a `combined.md` by prepending a pandoc title block (`% title / % author / % date`) to the source after passing it through `RenderHelpers.prune_frontmatter` (`bin/md2pdf:243`). Pandoc then reads `combined.md`. The render context is assembled in `Md2Pdf#render` (`bin/md2pdf:665`).
+
+## Gotcha: empty pruned frontmatter is a YAML trap
+
+`prune_frontmatter` strips keys md2pdf consumes (title, author, margin, fontsize, font, page_numbers, date — see `FRONTMATTER_CONSUMED` at `bin/md2pdf:70`). If a source file's frontmatter contains *only* consumed keys, naïvely keeping the `---/---` fences produces an empty YAML block:
+
+```
+---
+
+---
+```
+
+Pandoc treats the first `---` as a horizontal rule (empty body), then sees the second `---` (preceded by a blank line) as the **start** of a fresh YAML metadata block. It scans forward to the next `---` in the body (typically a section divider) and parses everything in between as YAML. If that body contains a line starting with `**` (bold markdown), YAML's alias scanner (`*` is the alias indicator) blows up with:
+
+```
+while scanning an alias:
+did not find expected alphabetic or numeric character
+```
+
+**Rule:** when modifying `prune_frontmatter`, always collapse to `""` if the pruned body is whitespace-only. Never leave bare `---/---` fences. Regression tests live in `tests/frontmatter_options.bats` under "fully-consumed frontmatter ...".
+
+## Testing pattern
+
+- `setup_fake_pandoc` in `tests/frontmatter_options.bats` installs a stub `pandoc` that captures the input file at `$MD2PDF_PANDOC_INPUT_LOG` and CLI args at `$MD2PDF_PANDOC_ARGS_LOG`. Use it to assert the exact bytes md2pdf hands to pandoc — fast, no LaTeX required.
+- For end-to-end checks against real pandoc+xelatex, gate with `has_pandoc_xelatex || skip` (`tests/test_helper.bash:9`).
+- Run `make test` (or `bats tests/`). Full suite is ~150 tests.
+
+## Local dev install
+
+The Homebrew formula installs to `/opt/homebrew/bin/md2pdf`. To iterate locally without touching the brew install, use `make install-dev`, which symlinks `~/.local/bin/md2pdf -> $(pwd)/bin/md2pdf`. `~/.local/bin` is earlier in PATH than `/opt/homebrew/bin` on the maintainer's setup, so the dev shim wins. `make uninstall-dev` reverts. `brew upgrade md2pdf` is unaffected.

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
 PREFIX ?= /usr/local
 BIN_DIR := $(PREFIX)/bin
+DEV_PREFIX ?= $(HOME)/.local
+DEV_BIN_DIR := $(DEV_PREFIX)/bin
 SRC_BIN := $(shell pwd)/bin/md2pdf
 VERSION_FILE := $(shell pwd)/VERSION
 
-.PHONY: install install-link uninstall test check-deps install-prereqs release-tag help
+.PHONY: install install-link install-dev uninstall uninstall-dev test check-deps install-prereqs release-tag help
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-15s %s\n", $$1, $$2}'
@@ -19,9 +21,29 @@ install-link: ## Install md2pdf to PREFIX/bin (symlink)
 	@ln -sf "$(SRC_BIN)" "$(BIN_DIR)/md2pdf"
 	@echo "Installed: $(BIN_DIR)/md2pdf -> $(SRC_BIN)"
 
+install-dev: ## Symlink dev build into DEV_PREFIX/bin (default ~/.local/bin) to shadow Homebrew
+	@mkdir -p "$(DEV_BIN_DIR)"
+	@ln -sf "$(SRC_BIN)" "$(DEV_BIN_DIR)/md2pdf"
+	@echo "Installed: $(DEV_BIN_DIR)/md2pdf -> $(SRC_BIN)"
+	@case ":$$PATH:" in \
+		*":$(DEV_BIN_DIR):"*) \
+			active="$$(command -v md2pdf)"; \
+			if [ "$$active" = "$(DEV_BIN_DIR)/md2pdf" ]; then \
+				echo "Active: $$active (dev shim wins)"; \
+			else \
+				echo "Warning: $$active is earlier in PATH than $(DEV_BIN_DIR); dev shim is shadowed."; \
+			fi ;; \
+		*) \
+			echo "Warning: $(DEV_BIN_DIR) is not in PATH; add it to your shell rc to activate the dev shim." ;; \
+	esac
+
 uninstall: ## Remove md2pdf from PREFIX/bin
 	@rm -f "$(BIN_DIR)/md2pdf"
 	@echo "Removed: $(BIN_DIR)/md2pdf"
+
+uninstall-dev: ## Remove dev shim from DEV_PREFIX/bin
+	@rm -f "$(DEV_BIN_DIR)/md2pdf"
+	@echo "Removed: $(DEV_BIN_DIR)/md2pdf"
 
 test: ## Run test suite (requires bats-core)
 	@command -v bats >/dev/null 2>&1 || { echo "bats-core is required: run 'make install-prereqs' or 'brew install bats-core'"; exit 1; }

--- a/bin/md2pdf
+++ b/bin/md2pdf
@@ -249,6 +249,11 @@ module RenderHelpers
       kept = prune_consumed_frontmatter_lines(body)
       kept = kept.gsub(/^(?:number_sections|number_section)([ \t]*:)/, "numbersections\\1")
 
+      # Drop the entire frontmatter block when nothing is left. A bare
+      # `---\n\n---` would otherwise mislead pandoc into treating a later
+      # body `---` as the start of a fresh YAML metadata block.
+      next "" if kept.strip.empty?
+
       "#{pre}#{kept}#{post}"
     end
   end

--- a/bin/md2pdf
+++ b/bin/md2pdf
@@ -47,6 +47,7 @@ DEFAULTS = {
   fontsize: "11pt",
   toc: true,
   page_numbers: true,
+  prevent_widows: false,
   mode: "pandoc-xelatex",
 }.freeze
 
@@ -54,7 +55,7 @@ MERMAID_NPM_PACKAGE = "@mermaid-js/mermaid-cli"
 MERMAID_BIN = "mmdc"
 
 # Frontmatter keys md2pdf understands (canonical names).
-FRONTMATTER_RECOGNIZED = %w[title author date margin fontsize font page_numbers toc numbersections].freeze
+FRONTMATTER_RECOGNIZED = %w[title author date margin fontsize font page_numbers toc numbersections prevent_widows].freeze
 
 # Aliased frontmatter keys mapped to their canonical name.
 FRONTMATTER_ALIASES = {
@@ -63,11 +64,13 @@ FRONTMATTER_ALIASES = {
   "pageNumbers" => "page_numbers",
   "number_sections" => "numbersections",
   "number_section" => "numbersections",
+  "prevent-widows" => "prevent_widows",
+  "preventWidows" => "prevent_widows",
 }.freeze
 
 # Keys md2pdf consumes itself (passed to renderers via flags), so they are stripped
 # from the frontmatter before pandoc reads it to avoid double-emission.
-FRONTMATTER_CONSUMED = %w[title author date margin fontsize font page_numbers].freeze
+FRONTMATTER_CONSUMED = %w[title author date margin fontsize font page_numbers prevent_widows].freeze
 
 # --- Mermaid preprocessor ---
 #
@@ -175,6 +178,15 @@ module RenderHelpers
       css << %(  @bottom-center { content: counter(page); font-family: "#{ctx[:font]}", serif; font-size: 9pt; }\n)
     end
     css << "}\n" << font_css(ctx)
+    css << widow_css if ctx[:prevent_widows]
+    css
+  end
+
+  # CSS widow/orphan protection. `widows` = min lines at top of page,
+  # `orphans` = min lines at bottom. Setting both to 3 forbids one- or
+  # two-line stragglers across page breaks (CSS spec default is 2).
+  def widow_css
+    "p, li, blockquote { widows: 3; orphans: 3; }\n"
   end
 
   def puppeteer_footer_html(ctx)
@@ -224,7 +236,7 @@ module RenderHelpers
       end
 
       case canonical
-      when "page_numbers", "toc", "numbersections"
+      when "page_numbers", "toc", "numbersections", "prevent_widows"
         bool = parse_frontmatter_bool(value)
         options[canonical.to_sym] = bool unless bool.nil?
       else
@@ -357,6 +369,9 @@ PANDOC_RENDER = ->(ctx) do
   cmd << "--toc" if ctx[:toc]
   if %w[xelatex lualatex pdflatex].include?(engine)
     cmd += ["-V", "pagestyle:#{ctx[:page_numbers] ? "plain" : "empty"}"]
+    if ctx[:prevent_widows]
+      cmd += ["-V", "header-includes:\\widowpenalty=10000 \\clubpenalty=10000 \\displaywidowpenalty=10000"]
+    end
   end
 
   [cmd]
@@ -446,7 +461,7 @@ MODES = {
     label: "Pandoc + XeLaTeX", runtime: "pandoc, xelatex", alias_tag: " [alias: latex]",
     note: "Default mode. Pandoc + XeLaTeX with title block, margin/font/TOC support. 'latex' is an alias.",
     engine: "xelatex", font_check: true,
-    supports: %i[title author margin fontsize font toc page_numbers mermaid],
+    supports: %i[title author margin fontsize font toc page_numbers prevent_widows mermaid],
     deps: { cmds: %w[pandoc xelatex] },
     install: { brew: %w[pandoc], brew_cask: %w[basictex font-noto-serif] },
     binary: { system: "pandoc" },
@@ -456,7 +471,7 @@ MODES = {
     label: "Pandoc + LuaLaTeX", runtime: "pandoc, lualatex",
     note: "Pandoc + LuaLaTeX. Unicode font support like XeLaTeX, useful for comparing TeX engines.",
     engine: "lualatex", font_check: true,
-    supports: %i[title author margin fontsize font toc page_numbers mermaid],
+    supports: %i[title author margin fontsize font toc page_numbers prevent_widows mermaid],
     deps: { cmds: %w[pandoc lualatex] },
     install: { brew: %w[pandoc], brew_cask: %w[basictex font-noto-serif] },
     binary: { system: "pandoc" },
@@ -466,7 +481,7 @@ MODES = {
     label: "Pandoc + pdfLaTeX", runtime: "pandoc, pdflatex",
     note: "Pandoc + pdfLaTeX. Best with ASCII content; Unicode and custom fonts are limited.",
     engine: "pdflatex",
-    supports: %i[title author margin fontsize toc page_numbers mermaid],
+    supports: %i[title author margin fontsize toc page_numbers prevent_widows mermaid],
     deps: { cmds: %w[pandoc pdflatex] },
     install: { brew: %w[pandoc], brew_cask: %w[basictex] },
     binary: { system: "pandoc" },
@@ -476,7 +491,7 @@ MODES = {
     label: "Pandoc + wkhtmltopdf", runtime: "pandoc, wkhtmltopdf",
     note: "Pandoc HTML pipeline + wkhtmltopdf. Margin/font via CSS. Author metadata not mapped.",
     engine: "wkhtmltopdf",
-    supports: %i[title margin fontsize font toc page_numbers mermaid],
+    supports: %i[title margin fontsize font toc page_numbers prevent_widows mermaid],
     deps: { cmds: %w[pandoc wkhtmltopdf] },
     install: { require: { "pandoc" => "brew install pandoc", "wkhtmltopdf" => "install via your preferred package manager" } },
     binary: { system: "pandoc" },
@@ -486,7 +501,7 @@ MODES = {
     label: "Pandoc + WeasyPrint", runtime: "pandoc, weasyprint",
     note: "Pandoc HTML pipeline + WeasyPrint. Margin/font via CSS. Author metadata not mapped.",
     engine: "weasyprint",
-    supports: %i[title margin fontsize font toc page_numbers mermaid],
+    supports: %i[title margin fontsize font toc page_numbers prevent_widows mermaid],
     deps: { cmds: %w[pandoc weasyprint] },
     install: { brew: %w[pandoc weasyprint] },
     binary: { system: "pandoc" },
@@ -552,6 +567,7 @@ class Md2Pdf
     @toc = nil
     @number_sections = nil
     @page_numbers = nil
+    @prevent_widows = nil
     @mermaid = true
     @title = nil
     @author = nil
@@ -595,6 +611,7 @@ class Md2Pdf
       opts.on("--[no-]toc", "Table of contents (default: on unless frontmatter sets toc)") { |v| @toc = v }
       opts.on("--[no-]number-sections", "Number section headings (default: on unless frontmatter or numbered H2 controls it)") { |v| @number_sections = v }
       opts.on("--[no-]page-numbers", "Page numbers (default: on)") { |v| @page_numbers = v }
+      opts.on("--[no-]prevent-widows", "Forbid widow/orphan lines across page breaks (default: off)") { |v| @prevent_widows = v }
       opts.on("--[no-]mermaid", "Pre-render fenced ```mermaid blocks via mmdc (default: on)") { |v| @mermaid = v }
       opts.on("--list-modes", "List modes and install status") { @action = :list_modes }
       opts.on("--check-deps", "Check deps for selected mode") { @action = :check_deps }
@@ -702,6 +719,7 @@ class Md2Pdf
       toc: !@toc.nil? ? @toc : (fm_options.key?(:toc) ? fm_options[:toc] : DEFAULTS[:toc]),
       toc_override: @toc,
       page_numbers: !@page_numbers.nil? ? @page_numbers : (fm_options.key?(:page_numbers) ? fm_options[:page_numbers] : DEFAULTS[:page_numbers]),
+      prevent_widows: !@prevent_widows.nil? ? @prevent_widows : (fm_options.key?(:prevent_widows) ? fm_options[:prevent_widows] : DEFAULTS[:prevent_widows]),
       engine: cfg[:engine],
       number_sections: RenderHelpers.resolve_number_sections(source_content, @number_sections),
       number_sections_override: @number_sections,

--- a/tests/frontmatter_options.bats
+++ b/tests/frontmatter_options.bats
@@ -285,3 +285,69 @@ write_doc() {
   [ "$status" -eq 0 ]
   [[ "$output" == *"warning: mode pandoc-pdflatex does not support arbitrary system font selection"* ]]
 }
+
+@test "fully-consumed frontmatter leaves no empty YAML block in pandoc input" {
+  setup_fake_pandoc
+  local input="$TEST_TEMP_DIR/fm-all-consumed.md"
+  write_doc "$input" "---" "fontsize: 11pt" "author: Jane Doe" "---" "" "# Title" "" "Body"
+
+  run "$MD2PDF" "$input" "$TEST_TEMP_DIR/out.pdf"
+
+  [ "$status" -eq 0 ]
+  # combined.md must not contain a bare `---\n\n---` empty YAML block,
+  # which pandoc reinterprets as a hr followed by a fresh YAML block start.
+  run python3 -c "import sys, re; sys.exit(0 if re.search(r'(?m)^---[ \t]*\n[ \t]*\n---[ \t]*$', open(sys.argv[1]).read()) is None else 1)" "$MD2PDF_PANDOC_INPUT_LOG"
+  [ "$status" -eq 0 ]
+}
+
+@test "fully-consumed frontmatter with body hr and bold does not crash pandoc" {
+  has_pandoc_xelatex || skip "pandoc and xelatex not available"
+
+  local input="$TEST_TEMP_DIR/regression-empty-fm.md"
+  cat > "$input" <<'MD'
+---
+fontsize: 11pt
+author: Alexander Goldstein
+---
+# Title
+
+**Bold paragraph** that follows a horizontal rule below.
+
+---
+
+## Section
+
+| A | B |
+|---|---|
+| 1 | 2 |
+MD
+
+  run "$MD2PDF" --no-toc "$input" "$TEST_TEMP_DIR/regression.pdf"
+  [ "$status" -eq 0 ]
+  [ -s "$TEST_TEMP_DIR/regression.pdf" ]
+}
+
+@test "frontmatter with only one consumed key leaves no empty YAML block" {
+  setup_fake_pandoc
+  local input="$TEST_TEMP_DIR/fm-one-consumed.md"
+  write_doc "$input" "---" "author: Solo" "---" "" "# Title" "" "Body"
+
+  run "$MD2PDF" "$input" "$TEST_TEMP_DIR/out.pdf"
+
+  [ "$status" -eq 0 ]
+  run python3 -c "import sys, re; sys.exit(0 if re.search(r'(?m)^---[ \t]*\n[ \t]*\n---[ \t]*$', open(sys.argv[1]).read()) is None else 1)" "$MD2PDF_PANDOC_INPUT_LOG"
+  [ "$status" -eq 0 ]
+}
+
+@test "frontmatter with surviving keys still emits non-empty YAML block" {
+  setup_fake_pandoc
+  local input="$TEST_TEMP_DIR/fm-mixed.md"
+  write_doc "$input" "---" "author: Solo" "toc: true" "---" "" "# Title" "" "Body"
+
+  run "$MD2PDF" "$input" "$TEST_TEMP_DIR/out.pdf"
+
+  [ "$status" -eq 0 ]
+  # toc must survive into the YAML block, author must be stripped.
+  grep -qx -- "toc: true" "$MD2PDF_PANDOC_INPUT_LOG"
+  ! grep -qx -- "author: Solo" "$MD2PDF_PANDOC_INPUT_LOG"
+}

--- a/tests/frontmatter_options.bats
+++ b/tests/frontmatter_options.bats
@@ -19,6 +19,15 @@ SH
 #!/usr/bin/env bash
 printf '%s\n' "$@" > "$MD2PDF_PANDOC_ARGS_LOG"
 cp "$1" "$MD2PDF_PANDOC_INPUT_LOG"
+saved_args=("$@")
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--css" ]; then
+    shift
+    [ -n "$MD2PDF_PANDOC_CSS_LOG" ] && [ -f "$1" ] && cp "$1" "$MD2PDF_PANDOC_CSS_LOG"
+  fi
+  shift
+done
+set -- "${saved_args[@]}"
 while [ "$#" -gt 0 ]; do
   if [ "$1" = "-o" ]; then
     shift
@@ -34,6 +43,7 @@ SH
   export PATH="$TEST_TEMP_DIR/fake-bin:$PATH"
   export MD2PDF_PANDOC_ARGS_LOG="$TEST_TEMP_DIR/pandoc-args.txt"
   export MD2PDF_PANDOC_INPUT_LOG="$TEST_TEMP_DIR/pandoc-input.md"
+  export MD2PDF_PANDOC_CSS_LOG="$TEST_TEMP_DIR/pandoc-css.txt"
 }
 
 write_doc() {
@@ -350,4 +360,125 @@ MD
   # toc must survive into the YAML block, author must be stripped.
   grep -qx -- "toc: true" "$MD2PDF_PANDOC_INPUT_LOG"
   ! grep -qx -- "author: Solo" "$MD2PDF_PANDOC_INPUT_LOG"
+}
+
+# --- Widow/orphan protection ----------------------------------------------
+
+@test "default behavior does not add LaTeX widow/club penalties" {
+  setup_fake_pandoc
+  local input="$TEST_TEMP_DIR/widow-default.md"
+  write_doc "$input" "# Title" "" "Body"
+
+  run "$MD2PDF" "$input" "$TEST_TEMP_DIR/out.pdf"
+
+  [ "$status" -eq 0 ]
+  ! grep -q "widowpenalty" "$MD2PDF_PANDOC_ARGS_LOG"
+  ! grep -q "clubpenalty" "$MD2PDF_PANDOC_ARGS_LOG"
+}
+
+@test "--prevent-widows adds LaTeX widow/club penalties for xelatex" {
+  setup_fake_pandoc
+  local input="$TEST_TEMP_DIR/widow-on.md"
+  write_doc "$input" "# Title" "" "Body"
+
+  run "$MD2PDF" --prevent-widows "$input" "$TEST_TEMP_DIR/out.pdf"
+
+  [ "$status" -eq 0 ]
+  grep -q '\\widowpenalty=10000' "$MD2PDF_PANDOC_ARGS_LOG"
+  grep -q '\\clubpenalty=10000' "$MD2PDF_PANDOC_ARGS_LOG"
+  grep -q '\\displaywidowpenalty=10000' "$MD2PDF_PANDOC_ARGS_LOG"
+}
+
+@test "--prevent-widows works for pdflatex too" {
+  setup_fake_pandoc
+  local input="$TEST_TEMP_DIR/widow-pdflatex.md"
+  write_doc "$input" "# Title" "" "Body"
+
+  run "$MD2PDF" --mode pandoc-pdflatex --prevent-widows "$input" "$TEST_TEMP_DIR/out.pdf"
+
+  [ "$status" -eq 0 ]
+  grep -q '\\widowpenalty=10000' "$MD2PDF_PANDOC_ARGS_LOG"
+}
+
+@test "frontmatter prevent_widows: true enables protection" {
+  setup_fake_pandoc
+  local input="$TEST_TEMP_DIR/widow-fm.md"
+  write_doc "$input" "---" "prevent_widows: true" "---" "" "# Title" "" "Body"
+
+  run "$MD2PDF" "$input" "$TEST_TEMP_DIR/out.pdf"
+
+  [ "$status" -eq 0 ]
+  grep -q '\\widowpenalty=10000' "$MD2PDF_PANDOC_ARGS_LOG"
+}
+
+@test "frontmatter alias prevent-widows is honored" {
+  setup_fake_pandoc
+  local input="$TEST_TEMP_DIR/widow-fm-alias.md"
+  write_doc "$input" "---" "prevent-widows: true" "---" "" "# Title" "" "Body"
+
+  run "$MD2PDF" "$input" "$TEST_TEMP_DIR/out.pdf"
+
+  [ "$status" -eq 0 ]
+  grep -q '\\widowpenalty=10000' "$MD2PDF_PANDOC_ARGS_LOG"
+}
+
+@test "CLI --no-prevent-widows overrides frontmatter true" {
+  setup_fake_pandoc
+  local input="$TEST_TEMP_DIR/widow-override.md"
+  write_doc "$input" "---" "prevent_widows: true" "---" "" "# Title" "" "Body"
+
+  run "$MD2PDF" --no-prevent-widows "$input" "$TEST_TEMP_DIR/out.pdf"
+
+  [ "$status" -eq 0 ]
+  ! grep -q "widowpenalty" "$MD2PDF_PANDOC_ARGS_LOG"
+}
+
+@test "prevent_widows is stripped from pandoc input" {
+  setup_fake_pandoc
+  local input="$TEST_TEMP_DIR/widow-stripped.md"
+  write_doc "$input" "---" "prevent_widows: true" "title: T" "---" "" "Body"
+
+  run "$MD2PDF" "$input" "$TEST_TEMP_DIR/out.pdf"
+
+  [ "$status" -eq 0 ]
+  ! grep -q "^prevent_widows:" "$MD2PDF_PANDOC_INPUT_LOG"
+}
+
+@test "weasyprint mode embeds CSS widows/orphans rules when --prevent-widows" {
+  setup_fake_pandoc
+  # weasyprint binary stub so dep check passes
+  cat > "$TEST_TEMP_DIR/fake-bin/weasyprint" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$TEST_TEMP_DIR/fake-bin/weasyprint"
+
+  local input="$TEST_TEMP_DIR/widow-css.md"
+  write_doc "$input" "# Title" "" "Body"
+
+  run "$MD2PDF" --mode pandoc-weasyprint --prevent-widows "$input" "$TEST_TEMP_DIR/out.pdf"
+
+  [ "$status" -eq 0 ]
+  [ -f "$MD2PDF_PANDOC_CSS_LOG" ]
+  grep -q "widows" "$MD2PDF_PANDOC_CSS_LOG"
+  grep -q "orphans" "$MD2PDF_PANDOC_CSS_LOG"
+}
+
+@test "weasyprint mode without --prevent-widows omits widows/orphans CSS" {
+  setup_fake_pandoc
+  cat > "$TEST_TEMP_DIR/fake-bin/weasyprint" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$TEST_TEMP_DIR/fake-bin/weasyprint"
+
+  local input="$TEST_TEMP_DIR/widow-css-off.md"
+  write_doc "$input" "# Title" "" "Body"
+
+  run "$MD2PDF" --mode pandoc-weasyprint "$input" "$TEST_TEMP_DIR/out.pdf"
+
+  [ "$status" -eq 0 ]
+  [ -f "$MD2PDF_PANDOC_CSS_LOG" ]
+  ! grep -q "widows" "$MD2PDF_PANDOC_CSS_LOG"
+  ! grep -q "orphans" "$MD2PDF_PANDOC_CSS_LOG"
 }


### PR DESCRIPTION
## Summary

- **Fix pandoc YAML crash** when a frontmatter block contains only md2pdf-consumed keys. `prune_frontmatter` was emitting bare \`---/---\` fences that pandoc reinterpreted as the start of a fresh YAML block, colliding with body \`**bold**\` text via YAML's \`*\` alias scanner. Now collapses to empty when the pruned body is whitespace-only.
- **Add \`--prevent-widows\` flag** (and \`prevent_widows:\` frontmatter key). Injects \`\\widowpenalty=10000 \\clubpenalty=10000 \\displaywidowpenalty=10000\` for LaTeX engines and \`widows: 3; orphans: 3\` CSS for HTML engines. Off by default.
- **Add \`make install-dev\`** to symlink the working copy into \`~/.local/bin\` so local edits shadow a Homebrew install without touching it. New \`AGENTS.md\` documents architecture, the YAML trap, the fake-pandoc test pattern, and the dev shim.

## Test plan

- [x] \`bats tests/\` — 156 tests, 0 failures (13 new: 4 for the YAML fix, 9 for widow protection)
- [x] End-to-end: original failing markdown now renders successfully with both default and \`--prevent-widows\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)