### PR TITLE
Add 'make release' wrapper for one-step tag + push

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ DEV_BIN_DIR := $(DEV_PREFIX)/bin
 SRC_BIN := $(shell pwd)/bin/md2pdf
 VERSION_FILE := $(shell pwd)/VERSION
 
-.PHONY: install install-link install-dev uninstall uninstall-dev test check-deps install-prereqs release-tag help
+.PHONY: install install-link install-dev uninstall uninstall-dev test check-deps install-prereqs release-tag release help
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-15s %s\n", $$1, $$2}'
@@ -64,6 +64,18 @@ release-tag: ## Bump VERSION (VERSION=X.Y.Z), update baked constant, commit, tag
 	@git commit -m "Release v$(VERSION)"
 	@git tag -a "v$(VERSION)" -m "v$(VERSION)"
 	@echo "Tagged v$(VERSION). Push with: git push origin master && git push origin v$(VERSION)"
+
+release: ## Bump, commit, tag, and push origin master + tag (triggers Homebrew tap PR)
+	@git fetch --quiet origin master
+	@if [ "$$(git rev-parse HEAD)" != "$$(git rev-parse origin/master)" ]; then \
+		echo "Refusing to release: HEAD is not at origin/master."; \
+		echo "  HEAD:           $$(git rev-parse --short HEAD) ($$(git rev-parse --abbrev-ref HEAD))"; \
+		echo "  origin/master:  $$(git rev-parse --short origin/master)"; \
+		exit 1; \
+	fi
+	@$(MAKE) release-tag VERSION=$(VERSION)
+	@git push origin HEAD:master
+	@git push origin "v$(VERSION)"
 
 install-prereqs: ## Install development prerequisites (bats-core)
 	@if command -v bats >/dev/null 2>&1; then \

--- a/README.md
+++ b/README.md
@@ -249,15 +249,25 @@ Unit tests run without any rendering engine installed. Integration tests automat
 ## Releasing
 
 ```bash
+make release VERSION=0.2.0
+```
+
+`release` runs `release-tag` (writes the new version to `VERSION` and to the
+`MD2PDF_VERSION` constant in `bin/md2pdf`, commits, and creates an annotated tag),
+then pushes `HEAD` to `origin/master` and pushes the new tag. It refuses to run
+unless `HEAD` is exactly at `origin/master`, so you can release from any local
+branch (including a Conductor workspace branch) as long as it's at the tip of
+master. To do those steps separately:
+
+```bash
 make release-tag VERSION=0.2.0
 git push origin master && git push origin v0.2.0
 ```
 
-`release-tag` writes the new version to `VERSION` and to the `MD2PDF_VERSION`
-constant in `bin/md2pdf`, commits, and creates an annotated tag. Pushing the tag
-triggers `.github/workflows/release.yml`, which computes the release tarball's
-sha256 and opens a PR against [`alexg0/homebrew-tap`](https://github.com/alexg0/homebrew-tap)
-updating `Formula/md2pdf.rb`.
+Pushing the tag triggers `.github/workflows/release.yml`, which computes the
+release tarball's sha256 and opens a PR against
+[`alexg0/homebrew-tap`](https://github.com/alexg0/homebrew-tap) updating
+`Formula/md2pdf.rb`.
 
 Prerequisite (one-time): create the `alexg0/homebrew-tap` repo, seed it with
 [`packaging/homebrew/md2pdf.rb`](packaging/homebrew/md2pdf.rb), and add a


### PR DESCRIPTION
Adds a `release` Make target that wraps `release-tag` with the push step, so cutting a release is one command instead of three.

Guards: refuses to run unless `HEAD` is exactly at `origin/master` (with a diagnostic showing the mismatch). This works from a Conductor workspace branch as long as it's at master's tip — `git push origin HEAD:master` puts the version-bump commit on master regardless of local branch name. The cross-repo Homebrew tap update still lives in `release.yml` (it needs `HOMEBREW_TAP_TOKEN`); the Makefile only handles the local prep + push.

README's Releasing section updated to document the new flow and keep the manual two-step path as an alternative.