### PR TITLE
Bump GitHub Actions to Node 24 versions, dedupe CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,7 @@ name: CI
 
 on:
   push:
-    branches:
-      - "**"
+    branches: [master]
   pull_request:
 
 permissions:
@@ -18,7 +17,7 @@ jobs:
     name: bats tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout md2pdf at the tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -32,7 +32,7 @@ jobs:
           echo "sha256=$sha256"       >> "$GITHUB_OUTPUT"
 
       - name: Checkout homebrew-tap
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: alexg0/homebrew-tap
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
@@ -64,7 +64,7 @@ jobs:
 
       - name: Open pull request
         id: cpr
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v7
         with:
           path: homebrew-tap
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}


### PR DESCRIPTION
## Summary
- Upgrade `actions/checkout@v4` → `@v5` and `peter-evans/create-pull-request@v6` → `@v7` to clear the Node.js 20 deprecation warning.
- Limit `ci.yml`'s `push` trigger to `master` so feature branches stop running CI twice (once on push, once on `pull_request`).

## Test plan
- [ ] CI passes on this PR (single run, not duplicated)
- [ ] No Node 20 deprecation warning in the run logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)