### PR TITLE
Add pandoc-docx mode for Microsoft Word output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # md2pdf
 
-Multi-engine Markdown to PDF converter. Supports 10 rendering backends with a unified CLI interface.
+Multi-engine Markdown to PDF (and DOCX) converter. Supports 11 rendering backends with a unified CLI interface.
 
 ## Features
 
-- **10 rendering backends** with automatic fallback and dependency management
+- **11 rendering backends** with automatic fallback and dependency management
 - Configurable title, author, margins, font size, and page numbering
 - Automatic table of contents generation (where supported)
 - Automatic title detection from first H1 heading
@@ -28,6 +28,7 @@ Multi-engine Markdown to PDF converter. Supports 10 rendering backends with a un
 | `go-md2pdf` | Go/fpdf | go |
 | `weasy-md2pdf` | Python/WeasyPrint | python3, brew |
 | `percollate` | Experimental HTML-first | pandoc, node, npm |
+| `pandoc-docx` (aliases: `docx`, `word`) | Pandoc → DOCX (Word) | pandoc, zip |
 
 ## Installation
 
@@ -81,7 +82,7 @@ md2pdf --install-deps-all
 ## Usage
 
 ```
-Usage: md2pdf [options] input.md [input2.md ...] [output.pdf | -o output.pdf]
+Usage: md2pdf [options] input.md [input2.md ...] [output.pdf|output.docx | -o PATH]
 
 Common options:
   --mode MODE         Renderer mode (default: pandoc-xelatex)
@@ -102,6 +103,9 @@ Common options:
                       Do not number section headings
   --mermaid           Pre-render fenced ```mermaid blocks via mmdc (default)
   --no-mermaid        Skip mermaid preprocessing
+  --reference-doc PATH
+                      DOCX template for pandoc-docx mode (controls fonts,
+                      margins, styles via Word's reference-doc mechanism)
 
 Actions:
   --list-modes        List modes and install status
@@ -220,6 +224,41 @@ required dependency. When fences are present but `mmdc` is missing, `md2pdf`
 exits with instructions to install it (`md2pdf --install-deps` for the
 selected mode, or `npm i -g @mermaid-js/mermaid-cli`). Pass `--no-mermaid` to
 leave fences untouched.
+
+## DOCX output
+
+Despite the name, `md2pdf` also produces Microsoft Word documents via the
+`pandoc-docx` mode (also accepts `--mode docx` or `--mode word`):
+
+```bash
+# Default output extension follows the mode (foo.md -> foo.docx)
+md2pdf --mode docx report.md
+
+# Or pass an explicit .docx path as the last positional
+md2pdf --mode docx report.md report.docx
+
+# Use a Word template to control fonts, margins, and paragraph styles
+md2pdf --mode word --reference-doc template.docx report.md
+```
+
+`--reference-doc` is forwarded to pandoc's `--reference-doc` flag. To create a
+starter template, run `pandoc -o template.docx --print-default-data-file reference.docx`,
+edit it in Word, then point `--reference-doc` at it.
+
+`pandoc-docx` honors `-t/--title`, `-a/--author`, `--toc`, `--number-sections`,
+and mermaid preprocessing. The same keys are also read from YAML frontmatter
+(`title`, `author`, `date`, `toc`, `numbersections`) — same precedence as the
+PDF modes (CLI > frontmatter > default). `margin`/`fontsize`/`font` are
+ignored (with warnings) because docx layout is template-driven; control them
+through `--reference-doc` instead. `--reference-doc` itself is CLI-only.
+
+`md2pdf` post-processes the docx to set `<w:updateFields w:val="true"/>` in
+`word/settings.xml`. Without it, Word opens the file with a blank TOC and
+prompts the user to "update fields" / "update external references" — pandoc
+emits TOC fields with no cached body that Word evaluates lazily. The patch
+asks Word to evaluate fields at open time so the TOC populates and the
+prompt is suppressed. Requires `unzip` and `zip` on PATH (preinstalled on
+macOS and most Linux distros).
 
 ## Configuration
 

--- a/bin/md2pdf
+++ b/bin/md2pdf
@@ -54,6 +54,12 @@ DEFAULTS = {
 MERMAID_NPM_PACKAGE = "@mermaid-js/mermaid-cli"
 MERMAID_BIN = "mmdc"
 
+MODE_ALIASES = {
+  "latex" => "pandoc-xelatex",
+  "docx" => "pandoc-docx",
+  "word" => "pandoc-docx",
+}.freeze
+
 # Frontmatter keys md2pdf understands (canonical names).
 FRONTMATTER_RECOGNIZED = %w[title author date margin fontsize font page_numbers toc numbersections prevent_widows].freeze
 
@@ -377,6 +383,31 @@ PANDOC_RENDER = ->(ctx) do
   [cmd]
 end
 
+# --- Pandoc DOCX render builder ---
+#
+# Pandoc produces .docx natively via `-o foo.docx` (no --pdf-engine).
+# Layout (margins/fonts/styles) is controlled by --reference-doc, not by
+# CSS or LaTeX flags, so margin/fontsize/font do not apply here.
+
+PANDOC_DOCX_RENDER = ->(ctx) do
+  tmpdir = ctx[:tmpdir]
+
+  content = "% #{ctx[:title]}\n% #{ctx[:author] || ""}\n% #{ctx[:date]}\n\n"
+  content << RenderHelpers.prune_frontmatter(File.read(ctx[:input], encoding: "utf-8"))
+  tmp_md = RenderHelpers.tmpfile(ctx, "combined.md", content)
+
+  cmd = %W[pandoc #{tmp_md} --resource-path=#{ctx[:resource_path]} -o #{ctx[:output]}]
+  cmd << "--number-sections" if ctx[:number_sections]
+  cmd << "--metadata=numbersections:true" if ctx[:number_sections_override] == true
+  cmd << "--metadata=numbersections:false" if ctx[:number_sections_override] == false
+  cmd << "--metadata=toc:true" if ctx[:toc_override] == true
+  cmd << "--metadata=toc:false" if ctx[:toc_override] == false
+  cmd << "--toc" if ctx[:toc]
+  cmd += ["--reference-doc", ctx[:reference_doc]] if ctx[:reference_doc]
+
+  [cmd]
+end
+
 # --- md-to-pdf render builder (Puppeteer + JSON config) ---
 
 MD_TO_PDF_RENDER = ->(ctx) do
@@ -552,6 +583,16 @@ MODES = {
     binary: { npm: { package: "percollate", bin: "percollate" } },
     render: PERCOLLATE_RENDER,
   },
+  "pandoc-docx" => {
+    label: "Pandoc -> DOCX", runtime: "pandoc, zip", alias_tag: " [aliases: docx, word]",
+    note: "Pandoc DOCX output. Title/author/TOC supported. Margin/font/fontsize come from --reference-doc. Aliases: 'docx', 'word'.",
+    output_ext: "docx",
+    supports: %i[title author toc mermaid reference_doc],
+    deps: { cmds: %w[pandoc unzip zip] },
+    install: { brew: %w[pandoc] },
+    binary: { system: "pandoc" },
+    render: PANDOC_DOCX_RENDER,
+  },
 }.freeze
 
 # ---------------------------------------------------------------------------
@@ -573,6 +614,7 @@ class Md2Pdf
     @author = nil
     @author_explicit = false
     @no_author = false
+    @reference_doc = nil
     @action = :render
     @input_files = []
     @output_file = nil
@@ -599,7 +641,7 @@ class Md2Pdf
   def parse_args(argv)
     args = argv.dup
     parser = OptionParser.new do |opts|
-      opts.banner = "Usage: #{$PROGRAM_NAME} [options] input.md [input2.md ...] [output.pdf | -o output.pdf]"
+      opts.banner = "Usage: #{$PROGRAM_NAME} [options] input.md [input2.md ...] [output.pdf|output.docx | -o PATH]"
       opts.on("--mode MODE", "Renderer mode (default: #{DEFAULTS[:mode]})") { |v| @mode = v }
       opts.on("-t TITLE", "PDF title") { |v| @title = v }
       opts.on("-a", "--author AUTHOR", "Author line (default: frontmatter author, then git config user.name)") { |v| @author = v; @author_explicit = true }
@@ -613,6 +655,7 @@ class Md2Pdf
       opts.on("--[no-]page-numbers", "Page numbers (default: on)") { |v| @page_numbers = v }
       opts.on("--[no-]prevent-widows", "Forbid widow/orphan lines across page breaks (default: off)") { |v| @prevent_widows = v }
       opts.on("--[no-]mermaid", "Pre-render fenced ```mermaid blocks via mmdc (default: on)") { |v| @mermaid = v }
+      opts.on("--reference-doc PATH", "DOCX template for pandoc-docx mode (controls fonts, margins, styles)") { |v| @reference_doc = v }
       opts.on("--list-modes", "List modes and install status") { @action = :list_modes }
       opts.on("--check-deps", "Check deps for selected mode") { @action = :check_deps }
       opts.on("--check-deps-all", "Check deps for all modes") { @action = :check_deps_all }
@@ -623,12 +666,12 @@ class Md2Pdf
     end
 
     remaining = parser.parse(args)
-    @mode = "pandoc-xelatex" if @mode == "latex"
+    @mode = MODE_ALIASES.fetch(@mode, @mode)
     abort "Unknown mode: #{@mode}" unless MODES.key?(@mode)
 
     if @output_file
       @input_files = remaining
-    elsif remaining.size > 1 && remaining.last.downcase.end_with?(".pdf")
+    elsif remaining.size > 1 && remaining.last.downcase.match?(/\.(pdf|docx)\z/)
       @output_file = remaining.pop
       @input_files = remaining
     elsif remaining.size > 1
@@ -685,8 +728,9 @@ class Md2Pdf
   # --- Unified render ---
 
   def render
-    abort "Usage: #{$PROGRAM_NAME} [options] input.md [input2.md ...] [output.pdf | -o output.pdf]\nRun with --help for details." if @input_files.empty?
+    abort "Usage: #{$PROGRAM_NAME} [options] input.md [input2.md ...] [output.pdf|output.docx | -o PATH]\nRun with --help for details." if @input_files.empty?
     @input_files.each { |f| abort "File not found: #{f}" unless File.file?(f) }
+    abort "Reference doc not found: #{@reference_doc}" if @reference_doc && !File.file?(@reference_doc)
 
     unless check_mode_deps(@mode)
       abort "Dependencies missing for mode '#{@mode}'. Run: #{$PROGRAM_NAME} --mode #{@mode} --install-deps"
@@ -724,11 +768,44 @@ class Md2Pdf
       number_sections: RenderHelpers.resolve_number_sections(source_content, @number_sections),
       number_sections_override: @number_sections,
       resource_path: build_resource_path,
+      reference_doc: @reference_doc,
     }
 
     cmds = cfg[:render].call(ctx)
     cmds.each { |cmd| run_cmd(*cmd) }
+    patch_docx_update_fields(resolved, tmpdir) if cfg[:output_ext] == "docx"
     puts resolved
+  end
+
+  # Pandoc emits the docx TOC as a "dirty" Word field whose body is empty —
+  # Word leaves the TOC blank and prompts the user to update fields/external
+  # references on open. Injecting <w:updateFields w:val="true"/> into
+  # settings.xml tells Word to evaluate fields automatically when the file
+  # opens, which populates the TOC and suppresses the prompt.
+  def patch_docx_update_fields(docx_path, tmpdir)
+    return unless File.file?(docx_path)
+    return unless have_cmd("unzip") && have_cmd("zip")
+
+    abs_docx = File.expand_path(docx_path)
+    patch_dir = File.join(tmpdir, "docx-patch")
+    FileUtils.mkdir_p(patch_dir)
+
+    return unless system("unzip", "-q", "-o", abs_docx, "word/settings.xml", "-d", patch_dir,
+                         out: File::NULL, err: File::NULL)
+
+    settings_path = File.join(patch_dir, "word", "settings.xml")
+    return unless File.file?(settings_path)
+
+    xml = File.read(settings_path)
+    return if xml.include?("<w:updateFields ")
+
+    patched = xml.sub("</w:settings>", '<w:updateFields w:val="true"/></w:settings>')
+    return if patched == xml
+
+    File.write(settings_path, patched)
+    Dir.chdir(patch_dir) do
+      system("zip", "-q", abs_docx, "word/settings.xml", exception: true)
+    end
   end
 
   def prepare_input(tmpdir)
@@ -818,6 +895,7 @@ class Md2Pdf
     @warnings << "mode #{@mode} ignores -s/--size" if @fontsize && !supports.include?(:fontsize)
     @warnings << "mode #{@mode} does not support arbitrary system font selection" if @font_family && !supports.include?(:font)
     @warnings << "mode #{@mode} does not support auto-generated TOC" if !@toc.nil? && !supports.include?(:toc)
+    @warnings << "mode #{@mode} ignores --reference-doc" if @reference_doc && !supports.include?(:reference_doc)
   end
 
   def warn_unmapped_frontmatter_options(options)
@@ -892,7 +970,8 @@ class Md2Pdf
   def resolve_output
     return @output_file if @output_file
     first = @input_files.first
-    File.join(File.dirname(first), "#{File.basename(first, ".md")}.pdf")
+    ext = cfg[:output_ext] || "pdf"
+    File.join(File.dirname(first), "#{File.basename(first, ".md")}.#{ext}")
   end
 
   def latex_date

--- a/tests/dependency_checking.bats
+++ b/tests/dependency_checking.bats
@@ -13,6 +13,7 @@ load test_helper
   [[ "$output" == *"go-md2pdf"* ]]
   [[ "$output" == *"weasy-md2pdf"* ]]
   [[ "$output" == *"percollate"* ]]
+  [[ "$output" == *"pandoc-docx"* ]]
 }
 
 @test "--list-modes shows status for each mode" {
@@ -28,7 +29,7 @@ load test_helper
 }
 
 @test "--mode-help shows info for each mode" {
-  for m in pandoc-xelatex pandoc-lualatex pandoc-pdflatex pandoc-wkhtmltopdf pandoc-weasyprint md-to-pdf mdpdf go-md2pdf weasy-md2pdf percollate; do
+  for m in pandoc-xelatex pandoc-lualatex pandoc-pdflatex pandoc-wkhtmltopdf pandoc-weasyprint md-to-pdf mdpdf go-md2pdf weasy-md2pdf percollate pandoc-docx; do
     run "$MD2PDF" --mode "$m" --mode-help
     [ "$status" -eq 0 ]
     [ -n "$output" ]

--- a/tests/mode_validation.bats
+++ b/tests/mode_validation.bats
@@ -57,6 +57,30 @@ load test_helper
   [ "$status" -eq 0 ]
 }
 
+@test "valid mode accepted: pandoc-docx" {
+  run "$MD2PDF" --mode pandoc-docx --mode-help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DOCX"* ]]
+}
+
+@test "docx alias resolves to pandoc-docx" {
+  run "$MD2PDF" --mode docx --mode-help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DOCX"* ]]
+}
+
+@test "word alias resolves to pandoc-docx" {
+  run "$MD2PDF" --mode word --mode-help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DOCX"* ]]
+}
+
+@test "alias_tag for pandoc-docx shown in --list-modes" {
+  run "$MD2PDF" --list-modes
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[aliases: docx, word]"* ]]
+}
+
 @test "invalid mode rejected" {
   run "$MD2PDF" --mode not-a-mode --mode-help
   [ "$status" -ne 0 ]
@@ -88,6 +112,7 @@ load test_helper
   [[ "$output" == *"Go/fpdf"* ]]
   [[ "$output" == *"Python/WeasyPrint"* ]]
   [[ "$output" == *"Experimental HTML-first"* ]]
+  [[ "$output" == *"Pandoc -> DOCX"* ]]
 }
 
 @test "mode_runtime shown in --list-modes" {
@@ -103,7 +128,7 @@ load test_helper
 }
 
 @test "mode_note is non-empty for all modes" {
-  for m in pandoc-xelatex pandoc-lualatex pandoc-pdflatex pandoc-wkhtmltopdf pandoc-weasyprint md-to-pdf mdpdf go-md2pdf weasy-md2pdf percollate; do
+  for m in pandoc-xelatex pandoc-lualatex pandoc-pdflatex pandoc-wkhtmltopdf pandoc-weasyprint md-to-pdf mdpdf go-md2pdf weasy-md2pdf percollate pandoc-docx; do
     run "$MD2PDF" --mode "$m" --mode-help
     [ "$status" -eq 0 ]
     [ -n "$output" ]

--- a/tests/output_resolution.bats
+++ b/tests/output_resolution.bats
@@ -35,3 +35,48 @@ load test_helper
   [ "$status" -eq 0 ]
   [ -f "$nested/x.pdf" ]
 }
+
+@test "pandoc-docx defaults output extension to .docx" {
+  command -v pandoc >/dev/null 2>&1 || skip "pandoc not available"
+  cp "$FIXTURES_DIR/sample.md" "$TEST_TEMP_DIR/sample.md"
+  run "$MD2PDF" --mode pandoc-docx "$TEST_TEMP_DIR/sample.md"
+  [ "$status" -eq 0 ]
+  [ -f "$TEST_TEMP_DIR/sample.docx" ]
+  [ ! -f "$TEST_TEMP_DIR/sample.pdf" ]
+}
+
+@test "pandoc-docx accepts trailing .docx as output positional" {
+  command -v pandoc >/dev/null 2>&1 || skip "pandoc not available"
+  run "$MD2PDF" --mode pandoc-docx "$FIXTURES_DIR/sample.md" "$TEST_TEMP_DIR/explicit.docx"
+  [ "$status" -eq 0 ]
+  [ -f "$TEST_TEMP_DIR/explicit.docx" ]
+}
+
+@test "pandoc-docx multi-input with trailing .docx concatenates" {
+  command -v pandoc >/dev/null 2>&1 || skip "pandoc not available"
+  run "$MD2PDF" --mode pandoc-docx "$FIXTURES_DIR/sample.md" "$FIXTURES_DIR/no-heading.md" "$TEST_TEMP_DIR/concat.docx"
+  [ "$status" -eq 0 ]
+  [ -f "$TEST_TEMP_DIR/concat.docx" ]
+}
+
+@test "missing --reference-doc file aborts" {
+  run "$MD2PDF" --mode pandoc-docx --reference-doc "$TEST_TEMP_DIR/nope.docx" "$FIXTURES_DIR/sample.md" "$TEST_TEMP_DIR/out.docx"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Reference doc not found"* ]]
+}
+
+@test "--reference-doc warns when used outside pandoc-docx" {
+  run "$MD2PDF" --mode pandoc-xelatex --reference-doc "$TEST_TEMP_DIR/anything.docx" --mode-help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ignores --reference-doc"* ]]
+}
+
+@test "pandoc-docx output has updateFields=true so Word populates TOC on open" {
+  command -v pandoc >/dev/null 2>&1 || skip "pandoc not available"
+  command -v unzip >/dev/null 2>&1 || skip "unzip not available"
+  run "$MD2PDF" --mode pandoc-docx --toc "$FIXTURES_DIR/sample.md" "$TEST_TEMP_DIR/withtoc.docx"
+  [ "$status" -eq 0 ]
+  run unzip -p "$TEST_TEMP_DIR/withtoc.docx" word/settings.xml
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'<w:updateFields w:val="true"/>'* ]]
+}


### PR DESCRIPTION
## Summary

- New `pandoc-docx` mode (aliases: `docx`, `word`) renders Markdown to Word `.docx` via pandoc; honors title/author/toc/numbersections from CLI and frontmatter, and adds `--reference-doc PATH` for fonts/margins/styles.
- Output extension is mode-aware: `.docx` is accepted as a trailing positional output, and the default output for `--mode docx report.md` is `report.docx`.
- Post-processes the docx to inject `<w:updateFields w:val="true"/>` into `word/settings.xml` so Word evaluates the TOC field on open instead of leaving it blank and prompting about external references.

## Test plan

- [x] `bats tests/` (166 tests passing, including 8 new docx-specific tests)
- [x] `md2pdf --mode docx tests/fixtures/sample.md` produces a valid `Microsoft Word 2007+` file
- [ ] Open the rendered docx in Word and confirm the TOC populates without the "external references" prompt