### PR TITLE
Harden release: retry tarball curl + bump create-pull-request to v8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,19 @@ jobs:
           tag="${GITHUB_REF#refs/tags/}"
           version="${tag#v}"
           tarball_url="https://github.com/${GITHUB_REPOSITORY}/archive/refs/tags/${tag}.tar.gz"
-          curl -fsSL -o release.tar.gz "$tarball_url"
+          # Retry: GitHub occasionally 502s the tag tarball in the seconds right after a tag is pushed.
+          for attempt in 1 2 3 4 5; do
+            if curl -fsSL -o release.tar.gz "$tarball_url"; then
+              break
+            fi
+            if [ "$attempt" -eq 5 ]; then
+              echo "::error::Failed to download $tarball_url after 5 attempts"
+              exit 1
+            fi
+            sleep_s=$((attempt * 5))
+            echo "curl failed (attempt $attempt/5), retrying in ${sleep_s}s..."
+            sleep "$sleep_s"
+          done
           sha256="$(shasum -a 256 release.tar.gz | awk '{print $1}')"
           echo "tag=$tag"             >> "$GITHUB_OUTPUT"
           echo "version=$version"     >> "$GITHUB_OUTPUT"
@@ -64,7 +76,7 @@ jobs:
 
       - name: Open pull request
         id: cpr
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           path: homebrew-tap
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}


### PR DESCRIPTION
## Summary
- Wrap the tag tarball `curl` in a 5-attempt linear-backoff retry. v0.2.0 release (run [24970915568](https://github.com/alexg0/md2pdf/actions/runs/24970915568)) failed on a transient `502` from GitHub fetching the just-pushed tag tarball; rerun succeeded. This stops that flake from breaking future releases.
- Bump `peter-evans/create-pull-request@v7` → `@v8`. PR #19 bumped to the then-latest v7 expecting it to clear the Node 20 deprecation warning, but v7 still ships Node 20 — v8 (released 2025-12-09) is the Node 24 release.

## Test plan
- [ ] Next tag push (`v0.2.1`+) runs cleanly with no Node 20 deprecation warning on the `Open pull request` step.
- [ ] If GitHub returns a transient 5xx for the tarball, the step retries and eventually succeeds (visible in logs as `curl failed (attempt N/5)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)