### PR TITLE
Allow -o to target output directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ Common options:
   -t TITLE            PDF title (default: first # H1 from file, or filename)
   -a, --author AUTHOR Author line (default: frontmatter `author:`, then `git config user.name`, then env vars)
   --no-author         Suppress author line entirely
-  -o, --output PATH   Output PDF path (required when passing multiple inputs
-                      unless the last positional ends in .pdf)
+  -o, --output PATH   Output path or directory (required when passing multiple inputs
+                      unless the last positional ends in .pdf or .docx)
   --font FONT         Preferred body font where supported (default: Noto Serif)
   -m MARGIN           Page margin (default: 1in)
   -s SIZE             Font size (default: 11pt)
@@ -127,6 +127,9 @@ md2pdf README.md
 
 # Specify output file
 md2pdf README.md output.pdf
+
+# Specify output directory (keeps input filename, changes extension for mode)
+md2pdf -o build/ README.md
 
 # Concatenate multiple inputs into a single PDF (last positional .pdf is output)
 md2pdf intro.md chapter1.md chapter2.md book.pdf

--- a/bin/md2pdf
+++ b/bin/md2pdf
@@ -646,7 +646,7 @@ class Md2Pdf
       opts.on("-t TITLE", "PDF title") { |v| @title = v }
       opts.on("-a", "--author AUTHOR", "Author line (default: frontmatter author, then git config user.name)") { |v| @author = v; @author_explicit = true }
       opts.on("--no-author", "Suppress author line entirely (overrides frontmatter and git fallback)") { @no_author = true }
-      opts.on("-o PATH", "--output PATH", "Output PDF path (required when passing multiple inputs)") { |v| @output_file = v }
+      opts.on("-o PATH", "--output PATH", "Output path or directory (required when passing multiple inputs)") { |v| @output_file = v }
       opts.on("--font FONT", "Body font") { |v| @font_family = v }
       opts.on("-m MARGIN", "Page margin (default: #{DEFAULTS[:margin]})") { |v| @margin = v }
       opts.on("-s SIZE", "Font size (default: #{DEFAULTS[:fontsize]})") { |v| @fontsize = v }
@@ -977,10 +977,22 @@ class Md2Pdf
   end
 
   def resolve_output
-    return @output_file if @output_file
     first = @input_files.first
     ext = cfg[:output_ext] || "pdf"
-    File.join(File.dirname(first), "#{File.basename(first, ".md")}.#{ext}")
+    default_name = "#{File.basename(first, ".md")}.#{ext}"
+
+    return File.join(@output_file, default_name) if output_directory_target?(@output_file)
+    return @output_file if @output_file
+
+    File.join(File.dirname(first), default_name)
+  end
+
+  def output_directory_target?(path)
+    return false unless path
+    return true if File.directory?(path)
+
+    separators = [File::SEPARATOR, File::ALT_SEPARATOR].compact
+    separators.any? { |separator| path.end_with?(separator) }
   end
 
   def latex_date

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -297,3 +297,30 @@
 - One-time prerequisite: create `alexg0/homebrew-tap` repo, drop `packaging/homebrew/md2pdf.rb` in as `Formula/md2pdf.rb` with the real sha256 from the first tarball, and add `HOMEBREW_TAP_TOKEN` PAT secret to this repo. (Done during this branch: tap repo created, formula seeded with placeholder sha256 that the release workflow will overwrite, secret set using the gh CLI token.)
 - Tarball URL pattern: `https://github.com/alexg0/md2pdf/archive/refs/tags/vX.Y.Z.tar.gz`.
 - Future releases: `make release-tag VERSION=X.Y.Z && git push origin master vX.Y.Z`.
+
+## Output Directory Target for -o
+
+- [x] Restate goal + acceptance criteria
+  - Goal: Let `-o/--output` accept a directory and write the converted file there using the input basename and mode-specific output extension.
+  - Acceptance: existing directory paths and trailing-slash directory paths work; explicit file output remains unchanged; parent directories are still auto-created.
+- [x] Locate existing implementation / patterns
+  - Output path handling is centralized in `Md2Pdf#resolve_output`.
+- [x] Design: minimal approach + key decisions
+  - Treat `-o` as a directory only when the path already exists as a directory or clearly ends with a directory separator.
+  - Preserve traditional explicit-file semantics for non-existing paths like `build/report.pdf`.
+- [x] Implement smallest safe slice
+- [x] Add/adjust tests
+- [x] Run verification
+- [x] Summarize changes + verification story
+- [x] Record lessons (if any)
+
+### Results
+
+- `-o DIR input.md` now resolves to `DIR/input.pdf` for PDF modes.
+- `--mode pandoc-docx -o DIR input.md` now resolves to `DIR/input.docx`.
+- `-o DIR/ input.md` creates `DIR/` and writes the mode-specific output filename there.
+- README usage now documents output directories.
+- Verification:
+  - `bats tests/output_resolution.bats` passed: 13 tests.
+  - `make test` passed: 172 tests.
+- Lessons: none; no correction or postmortem occurred.

--- a/tests/output_resolution.bats
+++ b/tests/output_resolution.bats
@@ -2,6 +2,31 @@
 
 load test_helper
 
+setup_fake_pandoc() {
+  mkdir -p "$TEST_TEMP_DIR/fake-bin"
+
+  cat > "$TEST_TEMP_DIR/fake-bin/xelatex" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+
+  cat > "$TEST_TEMP_DIR/fake-bin/pandoc" <<'SH'
+#!/usr/bin/env bash
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-o" ]; then
+    shift
+    touch "$1"
+    exit 0
+  fi
+  shift
+done
+exit 0
+SH
+
+  chmod +x "$TEST_TEMP_DIR/fake-bin/pandoc" "$TEST_TEMP_DIR/fake-bin/xelatex"
+  export PATH="$TEST_TEMP_DIR/fake-bin:$PATH"
+}
+
 @test "resolve_output_file defaults to .pdf extension" {
   has_pandoc_xelatex || skip "pandoc and xelatex not available"
   cp "$FIXTURES_DIR/sample.md" "$TEST_TEMP_DIR/sample.md"
@@ -36,6 +61,29 @@ load test_helper
   [ -f "$nested/x.pdf" ]
 }
 
+@test "-o existing directory keeps input filename with PDF extension" {
+  setup_fake_pandoc
+  cp "$FIXTURES_DIR/sample.md" "$TEST_TEMP_DIR/source.md"
+  local outdir="$TEST_TEMP_DIR/output"
+  mkdir -p "$outdir"
+
+  run "$MD2PDF" -o "$outdir" "$TEST_TEMP_DIR/source.md"
+
+  [ "$status" -eq 0 ]
+  [ -f "$outdir/source.pdf" ]
+}
+
+@test "-o trailing directory path creates directory and keeps input filename" {
+  setup_fake_pandoc
+  cp "$FIXTURES_DIR/sample.md" "$TEST_TEMP_DIR/source.md"
+  local outdir="$TEST_TEMP_DIR/new-output/"
+
+  run "$MD2PDF" -o "$outdir" "$TEST_TEMP_DIR/source.md"
+
+  [ "$status" -eq 0 ]
+  [ -f "$TEST_TEMP_DIR/new-output/source.pdf" ]
+}
+
 @test "pandoc-docx defaults output extension to .docx" {
   command -v pandoc >/dev/null 2>&1 || skip "pandoc not available"
   cp "$FIXTURES_DIR/sample.md" "$TEST_TEMP_DIR/sample.md"
@@ -57,6 +105,19 @@ load test_helper
   run "$MD2PDF" --mode pandoc-docx "$FIXTURES_DIR/sample.md" "$FIXTURES_DIR/no-heading.md" "$TEST_TEMP_DIR/concat.docx"
   [ "$status" -eq 0 ]
   [ -f "$TEST_TEMP_DIR/concat.docx" ]
+}
+
+@test "pandoc-docx -o directory keeps input filename with DOCX extension" {
+  setup_fake_pandoc
+  cp "$FIXTURES_DIR/sample.md" "$TEST_TEMP_DIR/source.md"
+  local outdir="$TEST_TEMP_DIR/docx-output"
+  mkdir -p "$outdir"
+
+  run "$MD2PDF" --mode pandoc-docx -o "$outdir" "$TEST_TEMP_DIR/source.md"
+
+  [ "$status" -eq 0 ]
+  [ -f "$outdir/source.docx" ]
+  [ ! -f "$outdir/source.pdf" ]
 }
 
 @test "missing --reference-doc file aborts" {


### PR DESCRIPTION
Allows -o/--output to accept an existing directory, or a trailing-slash directory path, and write the converted file there using the input basename with the selected mode's extension. Preserves explicit file output behavior for paths like build/report.pdf. Adds output-resolution regression coverage for PDF and DOCX modes and updates README usage. Verified with ruby -c bin/md2pdf, bats tests/output_resolution.bats, make test, and git diff --check.