### PR TITLE
Simplify md2pdf render helpers

### DIFF
--- a/bin/md2pdf
+++ b/bin/md2pdf
@@ -674,6 +674,8 @@ class Md2Pdf
 
   def cfg = MODES.fetch(@mode)
 
+  def supports?(feature) = cfg[:supports].include?(feature)
+
   # --- Argument parsing ---
 
   def parse_args(argv)
@@ -783,16 +785,29 @@ class Md2Pdf
     effective_input = prepare_input(tmpdir)
     source_content = File.read(effective_input, encoding: "utf-8")
     fm_options, unknown_keys = RenderHelpers.frontmatter_options(source_content)
-    unknown_keys.each { |k| warn "warning: unrecognized frontmatter key: #{k}" if warn_unknown_frontmatter_key?(k) }
+    warn_unknown_frontmatter_keys(unknown_keys)
     warn_unmapped_frontmatter_options(fm_options)
 
     resolved_font = @font_family || fm_options[:font] || DEFAULTS[:font_family]
     ensure_font(cfg[:engine], resolved_font) if cfg[:font_check]
 
-    input_path = preprocess_mermaid(source_content, tmpdir) || effective_input
+    ctx = render_context(
+      binary: binary, resolved: resolved, tmpdir: tmpdir,
+      effective_input: effective_input, source_content: source_content,
+      fm_options: fm_options, resolved_font: resolved_font
+    )
+    cmds = cfg[:render].call(ctx)
+    cmds.each { |cmd| run_cmd(*cmd) }
+    patch_docx_update_fields(resolved, tmpdir) if cfg[:output_ext] == "docx"
+    puts resolved
+  end
 
-    ctx = {
-      binary: binary, input: input_path, output: resolved, tmpdir: tmpdir,
+  def render_context(binary:, resolved:, tmpdir:, effective_input:, source_content:, fm_options:, resolved_font:)
+    {
+      binary: binary,
+      input: preprocess_mermaid(source_content, tmpdir) || effective_input,
+      output: resolved,
+      tmpdir: tmpdir,
       source_dir: File.dirname(File.expand_path(@input_files.first)),
       title: @title || fm_options[:title] || detect_title_from_source,
       author: resolve_author(fm_options),
@@ -800,21 +815,16 @@ class Md2Pdf
       margin: @margin || fm_options[:margin] || DEFAULTS[:margin],
       fontsize: @fontsize || fm_options[:fontsize] || DEFAULTS[:fontsize],
       font: resolved_font,
-      toc: !@toc.nil? ? @toc : (fm_options.key?(:toc) ? fm_options[:toc] : DEFAULTS[:toc]),
+      toc: resolved_option(@toc, fm_options, :toc, DEFAULTS[:toc]),
       toc_override: @toc,
-      page_numbers: !@page_numbers.nil? ? @page_numbers : (fm_options.key?(:page_numbers) ? fm_options[:page_numbers] : DEFAULTS[:page_numbers]),
-      prevent_widows: !@prevent_widows.nil? ? @prevent_widows : (fm_options.key?(:prevent_widows) ? fm_options[:prevent_widows] : DEFAULTS[:prevent_widows]),
+      page_numbers: resolved_option(@page_numbers, fm_options, :page_numbers, DEFAULTS[:page_numbers]),
+      prevent_widows: resolved_option(@prevent_widows, fm_options, :prevent_widows, DEFAULTS[:prevent_widows]),
       engine: cfg[:engine],
       number_sections: RenderHelpers.resolve_number_sections(source_content, @number_sections),
       number_sections_override: @number_sections,
       resource_path: build_resource_path,
       reference_doc: @reference_doc,
     }
-
-    cmds = cfg[:render].call(ctx)
-    cmds.each { |cmd| run_cmd(*cmd) }
-    patch_docx_update_fields(resolved, tmpdir) if cfg[:output_ext] == "docx"
-    puts resolved
   end
 
   # Pandoc emits the docx TOC as a "dirty" Word field whose body is empty —
@@ -923,26 +933,36 @@ class Md2Pdf
   # --- Config-driven unmapped option warnings ---
 
   def warn_unmapped_options
-    supports = cfg[:supports]
-    @warnings << "mode #{@mode} ignores -t/--title" if @title && !supports.include?(:title)
-    @warnings << "mode #{@mode} ignores -a/--author" if @author_explicit && !supports.include?(:author)
-    @warnings << "mode #{@mode} ignores -m/--margin" if @margin && !supports.include?(:margin)
-    @warnings << "mode #{@mode} ignores -s/--size" if @fontsize && !supports.include?(:fontsize)
-    @warnings << "mode #{@mode} does not support arbitrary system font selection" if @font_family && !supports.include?(:font)
-    @warnings << "mode #{@mode} does not support auto-generated TOC" if !@toc.nil? && !supports.include?(:toc)
-    @warnings << "mode #{@mode} ignores --reference-doc" if @reference_doc && !supports.include?(:reference_doc)
+    warn_unmapped_option(:title, @title, "mode #{@mode} ignores -t/--title")
+    warn_unmapped_option(:author, @author_explicit, "mode #{@mode} ignores -a/--author")
+    warn_unmapped_option(:margin, @margin, "mode #{@mode} ignores -m/--margin")
+    warn_unmapped_option(:fontsize, @fontsize, "mode #{@mode} ignores -s/--size")
+    warn_unmapped_option(:font, @font_family, "mode #{@mode} does not support arbitrary system font selection")
+    warn_unmapped_option(:toc, !@toc.nil?, "mode #{@mode} does not support auto-generated TOC")
+    warn_unmapped_option(:reference_doc, @reference_doc, "mode #{@mode} ignores --reference-doc")
   end
 
   def warn_unmapped_frontmatter_options(options)
-    supports = cfg[:supports]
-    warn "warning: mode #{@mode} ignores frontmatter title" if !@title && options.key?(:title) && !supports.include?(:title)
-    warn "warning: mode #{@mode} ignores frontmatter author" if !@author && options.key?(:author) && !supports.include?(:author)
-    warn "warning: mode #{@mode} ignores frontmatter margin" if !@margin && options.key?(:margin) && !supports.include?(:margin)
-    warn "warning: mode #{@mode} ignores frontmatter fontsize" if !@fontsize && options.key?(:fontsize) && !supports.include?(:fontsize)
-    if !@font_family && options.key?(:font) && !supports.include?(:font)
-      warn "warning: mode #{@mode} does not support arbitrary system font selection"
-    end
-    warn "warning: mode #{@mode} does not support auto-generated TOC" if @toc.nil? && options.key?(:toc) && !supports.include?(:toc)
+    warn_unmapped_frontmatter_option(:title, options, overridden: @title, message: "mode #{@mode} ignores frontmatter title")
+    warn_unmapped_frontmatter_option(:author, options, overridden: @author, message: "mode #{@mode} ignores frontmatter author")
+    warn_unmapped_frontmatter_option(:margin, options, overridden: @margin, message: "mode #{@mode} ignores frontmatter margin")
+    warn_unmapped_frontmatter_option(:fontsize, options, overridden: @fontsize, message: "mode #{@mode} ignores frontmatter fontsize")
+    warn_unmapped_frontmatter_option(:font, options, overridden: @font_family,
+      message: "mode #{@mode} does not support arbitrary system font selection")
+    warn_unmapped_frontmatter_option(:toc, options, overridden: !@toc.nil?,
+      message: "mode #{@mode} does not support auto-generated TOC")
+  end
+
+  def warn_unmapped_option(feature, used, message)
+    @warnings << message if used && !supports?(feature)
+  end
+
+  def warn_unmapped_frontmatter_option(feature, options, overridden:, message:)
+    warn "warning: #{message}" if !overridden && options.key?(feature) && !supports?(feature)
+  end
+
+  def warn_unknown_frontmatter_keys(keys)
+    keys.each { |key| warn "warning: unrecognized frontmatter key: #{key}" if warn_unknown_frontmatter_key?(key) }
   end
 
   def warn_unknown_frontmatter_key?(key)
@@ -957,6 +977,13 @@ class Md2Pdf
   end
 
   # --- Helpers ---
+
+  def resolved_option(cli_value, fm_options, key, default)
+    return cli_value unless cli_value.nil?
+    return fm_options[key] if fm_options.key?(key)
+
+    default
+  end
 
   def detect_title_from_source
     first = @input_files.first
@@ -1182,7 +1209,7 @@ class Md2Pdf
 
   def preprocess_mermaid(content, tmpdir)
     return nil unless @mermaid
-    return nil unless cfg[:supports].include?(:mermaid)
+    return nil unless supports?(:mermaid)
     return nil unless MermaidPreprocessor.has_blocks?(content)
 
     mmdc = locate_mmdc

--- a/bin/md2pdf
+++ b/bin/md2pdf
@@ -250,6 +250,28 @@ module RenderHelpers
     path
   end
 
+  def pandoc_markdown(ctx, normalize_unicode: false)
+    content = "% #{ctx[:title]}\n% #{ctx[:author] || ""}\n% #{ctx[:date]}\n\n"
+    content << prune_frontmatter(File.read(ctx[:input], encoding: "utf-8"))
+    normalize_latex_unicode!(content, ctx[:engine]) if normalize_unicode
+    tmpfile(ctx, "combined.md", content)
+  end
+
+  def normalize_latex_unicode!(content, engine)
+    LATEX_UNICODE.each { |k, v| content.gsub!(k) { v } }
+    LATEX_SYMBOLS.each { |k, v| content.gsub!(k) { v } } if %w[xelatex lualatex pdflatex].include?(engine)
+    PDFLATEX_EXTRA.each { |k, v| content.gsub!(k) { v } } if engine == "pdflatex"
+  end
+
+  def add_pandoc_document_flags(cmd, ctx)
+    cmd << "--number-sections" if ctx[:number_sections]
+    cmd << "--metadata=numbersections:true" if ctx[:number_sections_override] == true
+    cmd << "--metadata=numbersections:false" if ctx[:number_sections_override] == false
+    cmd << "--metadata=toc:true" if ctx[:toc_override] == true
+    cmd << "--metadata=toc:false" if ctx[:toc_override] == false
+    cmd << "--toc" if ctx[:toc]
+  end
+
   def number_sections?(content)
     !frontmatter_controls_numbering?(content) && !numbered_h2?(content)
   end
@@ -375,25 +397,11 @@ end
 
 PANDOC_RENDER = ->(ctx) do
   engine = ctx[:engine]
-  tmpdir = ctx[:tmpdir]
-
-  # Preprocess: title block + unicode normalization
-  content = "% #{ctx[:title]}\n% #{ctx[:author] || ""}\n% #{ctx[:date]}\n\n"
-  content << RenderHelpers.prune_frontmatter(File.read(ctx[:input], encoding: "utf-8"))
-  LATEX_UNICODE.each { |k, v| content.gsub!(k) { v } }
-  if %w[xelatex lualatex pdflatex].include?(engine)
-    LATEX_SYMBOLS.each { |k, v| content.gsub!(k) { v } }
-  end
-  PDFLATEX_EXTRA.each { |k, v| content.gsub!(k) { v } } if engine == "pdflatex"
-  tmp_md = RenderHelpers.tmpfile(ctx, "combined.md", content)
+  tmp_md = RenderHelpers.pandoc_markdown(ctx, normalize_unicode: true)
 
   cmd = %W[pandoc #{tmp_md} --resource-path=#{ctx[:resource_path]}
            --pdf-engine=#{engine} -V linkcolor:blue -V urlcolor:blue -o #{ctx[:output]}]
-  cmd << "--number-sections" if ctx[:number_sections]
-  cmd << "--metadata=numbersections:true" if ctx[:number_sections_override] == true
-  cmd << "--metadata=numbersections:false" if ctx[:number_sections_override] == false
-  cmd << "--metadata=toc:true" if ctx[:toc_override] == true
-  cmd << "--metadata=toc:false" if ctx[:toc_override] == false
+  RenderHelpers.add_pandoc_document_flags(cmd, ctx)
 
   case engine
   when "xelatex", "lualatex"
@@ -410,7 +418,6 @@ PANDOC_RENDER = ->(ctx) do
     end
   end
 
-  cmd << "--toc" if ctx[:toc]
   if %w[xelatex lualatex pdflatex].include?(engine)
     cmd += ["-V", "pagestyle:#{ctx[:page_numbers] ? "plain" : "empty"}"]
     if ctx[:prevent_widows]
@@ -428,19 +435,10 @@ end
 # CSS or LaTeX flags, so margin/fontsize/font do not apply here.
 
 PANDOC_DOCX_RENDER = ->(ctx) do
-  tmpdir = ctx[:tmpdir]
-
-  content = "% #{ctx[:title]}\n% #{ctx[:author] || ""}\n% #{ctx[:date]}\n\n"
-  content << RenderHelpers.prune_frontmatter(File.read(ctx[:input], encoding: "utf-8"))
-  tmp_md = RenderHelpers.tmpfile(ctx, "combined.md", content)
+  tmp_md = RenderHelpers.pandoc_markdown(ctx)
 
   cmd = %W[pandoc #{tmp_md} --resource-path=#{ctx[:resource_path]} -o #{ctx[:output]}]
-  cmd << "--number-sections" if ctx[:number_sections]
-  cmd << "--metadata=numbersections:true" if ctx[:number_sections_override] == true
-  cmd << "--metadata=numbersections:false" if ctx[:number_sections_override] == false
-  cmd << "--metadata=toc:true" if ctx[:toc_override] == true
-  cmd << "--metadata=toc:false" if ctx[:toc_override] == false
-  cmd << "--toc" if ctx[:toc]
+  RenderHelpers.add_pandoc_document_flags(cmd, ctx)
   cmd += ["--reference-doc", ctx[:reference_doc]] if ctx[:reference_doc]
 
   [cmd]

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,37 @@
+## Simplification Pass
+
+- [x] Restate goal + acceptance criteria
+  - Goal: simplify the implementation and consolidate/combine tests where appropriate without changing user-visible behavior.
+  - Acceptance: duplicated pandoc rendering/test setup is reduced; existing CLI/render behavior remains covered; syntax and tests pass.
+- [x] Locate existing implementation / patterns
+- [x] Design: minimal approach + key decisions
+- [x] Implement smallest safe slice
+- [x] Add/adjust tests
+- [x] Run verification (lint/tests/build/manual repro)
+- [x] Summarize changes + verification story
+- [x] Record lessons (if any)
+
+### Working Notes
+
+- `bin/md2pdf` is still a single-file Ruby CLI; keep changes local and avoid introducing new dependencies.
+- `PANDOC_RENDER` and `PANDOC_DOCX_RENDER` duplicate title-block input construction and metadata override flags.
+- Multiple Bats files duplicate fake-pandoc setup helpers.
+
+### Results
+
+- Extracted shared pandoc markdown generation into `RenderHelpers.pandoc_markdown`.
+- Extracted shared pandoc CLI metadata/TOC flags into `RenderHelpers.add_pandoc_document_flags`.
+- Kept Unicode normalization explicit for PDF pandoc renderers so DOCX behavior stays unchanged.
+- Moved fake pandoc/TeX setup, markdown fixture writing, and argument assertions into `tests/test_helper.bash`.
+- Removed duplicated fake-pandoc setup from frontmatter, section-numbering, author, unicode, mermaid, and output-resolution tests.
+- Verification:
+  - `ruby -c bin/md2pdf` — Syntax OK.
+  - `bats tests/frontmatter_options.bats tests/section_numbering.bats tests/author_resolution.bats tests/unicode_normalization.bats` — 77 tests passed.
+  - `bats tests/frontmatter_options.bats tests/section_numbering.bats tests/author_resolution.bats tests/unicode_normalization.bats tests/mermaid_preprocessing.bats tests/output_resolution.bats` — 97 tests passed.
+  - `make test` — 179 tests passed.
+  - `git diff --check` — passed.
+- Lessons: none; no correction or postmortem was needed.
+
 ## Unknown Frontmatter PDF Error
 
 - [x] Restate goal + acceptance criteria

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,38 @@
+## Implementation Simplification Pass 2
+
+- [x] Restate goal + acceptance criteria
+  - Goal: refactor and simplify implementation while confirming no degradation of user-visible behavior.
+  - Acceptance: implementation complexity is reduced with no CLI/output behavior changes; existing tests continue to pass; any changed behavior surface is covered by focused tests.
+- [x] Locate existing implementation / patterns
+- [x] Design: minimal approach + key decisions
+- [x] Implement smallest safe slice
+- [x] Add/adjust tests
+- [x] Run verification (lint/tests/build/manual repro)
+- [x] Summarize changes + verification story
+- [x] Record lessons (if any)
+
+### Working Notes
+
+- Start from committed branch `alexg0/simplify-code-tests`; keep this as a follow-up commit-sized slice.
+- Prefer extracting repeated option-resolution and warning patterns over changing renderer behavior.
+- Extract small helpers only: avoid table-driven metaprogramming so the warning messages and precedence remain obvious.
+
+### Results
+
+- Added `supports?` to centralize mode feature checks.
+- Added `resolved_option` for CLI > frontmatter > default precedence on boolean render options.
+- Added small warning helpers for unsupported CLI/frontmatter options while preserving exact warning messages.
+- Extracted `render_context` so `render` focuses on orchestration and command execution instead of constructing every renderer option inline.
+- Extracted `warn_unknown_frontmatter_keys` and reused `supports?` for mermaid preprocessing checks.
+- No new tests were needed; this pass is covered by existing warning, frontmatter, section-numbering, and full behavior tests.
+- Verification:
+  - `ruby -c bin/md2pdf` — Syntax OK.
+  - `bats tests/warning_system.bats tests/frontmatter_options.bats tests/section_numbering.bats` — 62 tests passed.
+  - `bats tests/frontmatter_options.bats tests/mermaid_preprocessing.bats tests/output_resolution.bats tests/warning_system.bats tests/section_numbering.bats` — 82 tests passed.
+  - `make test` — 179 tests passed.
+  - `git diff --check` — passed.
+- Lessons: none; no correction or postmortem was needed.
+
 ## Simplification Pass
 
 - [x] Restate goal + acceptance criteria

--- a/tests/author_resolution.bats
+++ b/tests/author_resolution.bats
@@ -2,35 +2,6 @@
 
 load test_helper
 
-setup_fake_pandoc() {
-  mkdir -p "$TEST_TEMP_DIR/fake-bin"
-
-  cat > "$TEST_TEMP_DIR/fake-bin/xelatex" <<'SH'
-#!/usr/bin/env bash
-exit 0
-SH
-
-  cat > "$TEST_TEMP_DIR/fake-bin/pandoc" <<'SH'
-#!/usr/bin/env bash
-printf '%s\n' "$@" > "$MD2PDF_PANDOC_ARGS_LOG"
-cp "$1" "$MD2PDF_PANDOC_INPUT_LOG"
-while [ "$#" -gt 0 ]; do
-  if [ "$1" = "-o" ]; then
-    shift
-    touch "$1"
-    exit 0
-  fi
-  shift
-done
-exit 0
-SH
-
-  chmod +x "$TEST_TEMP_DIR/fake-bin/pandoc" "$TEST_TEMP_DIR/fake-bin/xelatex"
-  export PATH="$TEST_TEMP_DIR/fake-bin:$PATH"
-  export MD2PDF_PANDOC_ARGS_LOG="$TEST_TEMP_DIR/pandoc-args.txt"
-  export MD2PDF_PANDOC_INPUT_LOG="$TEST_TEMP_DIR/pandoc-input.md"
-}
-
 # Install a fake `git` shim that returns a configured user.name. The shim is
 # placed in fake-bin and shadows the real git for the test process.
 install_fake_git() {
@@ -54,12 +25,6 @@ install_failing_git() {
 exit 1
 SH
   chmod +x "$TEST_TEMP_DIR/fake-bin/git"
-}
-
-write_doc() {
-  local path="$1"
-  shift
-  printf '%s\n' "$@" > "$path"
 }
 
 # Strip the env so leftover GIT_AUTHOR_NAME etc. from the surrounding shell

--- a/tests/frontmatter_options.bats
+++ b/tests/frontmatter_options.bats
@@ -2,56 +2,6 @@
 
 load test_helper
 
-setup_fake_pandoc() {
-  mkdir -p "$TEST_TEMP_DIR/fake-bin"
-
-  cat > "$TEST_TEMP_DIR/fake-bin/xelatex" <<'SH'
-#!/usr/bin/env bash
-exit 0
-SH
-
-  cat > "$TEST_TEMP_DIR/fake-bin/pdflatex" <<'SH'
-#!/usr/bin/env bash
-exit 0
-SH
-
-  cat > "$TEST_TEMP_DIR/fake-bin/pandoc" <<'SH'
-#!/usr/bin/env bash
-printf '%s\n' "$@" > "$MD2PDF_PANDOC_ARGS_LOG"
-cp "$1" "$MD2PDF_PANDOC_INPUT_LOG"
-saved_args=("$@")
-while [ "$#" -gt 0 ]; do
-  if [ "$1" = "--css" ]; then
-    shift
-    [ -n "$MD2PDF_PANDOC_CSS_LOG" ] && [ -f "$1" ] && cp "$1" "$MD2PDF_PANDOC_CSS_LOG"
-  fi
-  shift
-done
-set -- "${saved_args[@]}"
-while [ "$#" -gt 0 ]; do
-  if [ "$1" = "-o" ]; then
-    shift
-    touch "$1"
-    exit 0
-  fi
-  shift
-done
-exit 0
-SH
-
-  chmod +x "$TEST_TEMP_DIR/fake-bin/pandoc" "$TEST_TEMP_DIR/fake-bin/xelatex" "$TEST_TEMP_DIR/fake-bin/pdflatex"
-  export PATH="$TEST_TEMP_DIR/fake-bin:$PATH"
-  export MD2PDF_PANDOC_ARGS_LOG="$TEST_TEMP_DIR/pandoc-args.txt"
-  export MD2PDF_PANDOC_INPUT_LOG="$TEST_TEMP_DIR/pandoc-input.md"
-  export MD2PDF_PANDOC_CSS_LOG="$TEST_TEMP_DIR/pandoc-css.txt"
-}
-
-write_doc() {
-  local path="$1"
-  shift
-  printf '%s\n' "$@" > "$path"
-}
-
 @test "frontmatter title is used as title block" {
   setup_fake_pandoc
   local input="$TEST_TEMP_DIR/fm-title.md"

--- a/tests/mermaid_preprocessing.bats
+++ b/tests/mermaid_preprocessing.bats
@@ -2,38 +2,6 @@
 
 load test_helper
 
-# Build a fake-bin directory containing fake pandoc + xelatex (so we don't need
-# the real renderer toolchain). The fake pandoc logs argv and the input markdown
-# it received, then writes an empty PDF to -o. The fake xelatex always succeeds.
-setup_fake_pandoc() {
-  mkdir -p "$TEST_TEMP_DIR/fake-bin"
-
-  cat > "$TEST_TEMP_DIR/fake-bin/xelatex" <<'SH'
-#!/usr/bin/env bash
-exit 0
-SH
-
-  cat > "$TEST_TEMP_DIR/fake-bin/pandoc" <<'SH'
-#!/usr/bin/env bash
-printf '%s\n' "$@" > "$MD2PDF_PANDOC_ARGS_LOG"
-cp "$1" "$MD2PDF_PANDOC_INPUT_LOG"
-while [ "$#" -gt 0 ]; do
-  if [ "$1" = "-o" ]; then
-    shift
-    touch "$1"
-    exit 0
-  fi
-  shift
-done
-exit 0
-SH
-
-  chmod +x "$TEST_TEMP_DIR/fake-bin/pandoc" "$TEST_TEMP_DIR/fake-bin/xelatex"
-  export PATH="$TEST_TEMP_DIR/fake-bin:$PATH"
-  export MD2PDF_PANDOC_ARGS_LOG="$TEST_TEMP_DIR/pandoc-args.txt"
-  export MD2PDF_PANDOC_INPUT_LOG="$TEST_TEMP_DIR/pandoc-input.md"
-}
-
 # Add a fake mmdc that records each invocation and produces an empty PNG.
 setup_fake_mmdc() {
   export MD2PDF_MMDC_CALLS_LOG="$TEST_TEMP_DIR/mmdc-calls.log"

--- a/tests/output_resolution.bats
+++ b/tests/output_resolution.bats
@@ -2,31 +2,6 @@
 
 load test_helper
 
-setup_fake_pandoc() {
-  mkdir -p "$TEST_TEMP_DIR/fake-bin"
-
-  cat > "$TEST_TEMP_DIR/fake-bin/xelatex" <<'SH'
-#!/usr/bin/env bash
-exit 0
-SH
-
-  cat > "$TEST_TEMP_DIR/fake-bin/pandoc" <<'SH'
-#!/usr/bin/env bash
-while [ "$#" -gt 0 ]; do
-  if [ "$1" = "-o" ]; then
-    shift
-    touch "$1"
-    exit 0
-  fi
-  shift
-done
-exit 0
-SH
-
-  chmod +x "$TEST_TEMP_DIR/fake-bin/pandoc" "$TEST_TEMP_DIR/fake-bin/xelatex"
-  export PATH="$TEST_TEMP_DIR/fake-bin:$PATH"
-}
-
 @test "resolve_output_file defaults to .pdf extension" {
   has_pandoc_xelatex || skip "pandoc and xelatex not available"
   cp "$FIXTURES_DIR/sample.md" "$TEST_TEMP_DIR/sample.md"

--- a/tests/section_numbering.bats
+++ b/tests/section_numbering.bats
@@ -2,49 +2,6 @@
 
 load test_helper
 
-setup_fake_pandoc() {
-  mkdir -p "$TEST_TEMP_DIR/fake-bin"
-
-  cat > "$TEST_TEMP_DIR/fake-bin/xelatex" <<'SH'
-#!/usr/bin/env bash
-exit 0
-SH
-
-  cat > "$TEST_TEMP_DIR/fake-bin/pandoc" <<'SH'
-#!/usr/bin/env bash
-printf '%s\n' "$@" > "$MD2PDF_PANDOC_ARGS_LOG"
-cp "$1" "$MD2PDF_PANDOC_INPUT_LOG"
-while [ "$#" -gt 0 ]; do
-  if [ "$1" = "-o" ]; then
-    shift
-    touch "$1"
-    exit 0
-  fi
-  shift
-done
-exit 0
-SH
-
-  chmod +x "$TEST_TEMP_DIR/fake-bin/pandoc" "$TEST_TEMP_DIR/fake-bin/xelatex"
-  export PATH="$TEST_TEMP_DIR/fake-bin:$PATH"
-  export MD2PDF_PANDOC_ARGS_LOG="$TEST_TEMP_DIR/pandoc-args.txt"
-  export MD2PDF_PANDOC_INPUT_LOG="$TEST_TEMP_DIR/pandoc-input.md"
-}
-
-write_doc() {
-  local path="$1"
-  shift
-  printf '%s\n' "$@" > "$path"
-}
-
-assert_arg_present() {
-  grep -qx -- "$1" "$MD2PDF_PANDOC_ARGS_LOG"
-}
-
-assert_arg_absent() {
-  ! grep -qx -- "$1" "$MD2PDF_PANDOC_ARGS_LOG"
-}
-
 @test "default pandoc render numbers sections" {
   setup_fake_pandoc
   local input="$TEST_TEMP_DIR/default.md"

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -10,6 +10,62 @@ has_pandoc_xelatex() {
   command -v pandoc >/dev/null 2>&1 && command -v xelatex >/dev/null 2>&1
 }
 
+setup_fake_pandoc() {
+  mkdir -p "$TEST_TEMP_DIR/fake-bin"
+
+  for engine in xelatex lualatex pdflatex; do
+    cat > "$TEST_TEMP_DIR/fake-bin/$engine" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+    chmod +x "$TEST_TEMP_DIR/fake-bin/$engine"
+  done
+
+  cat > "$TEST_TEMP_DIR/fake-bin/pandoc" <<'SH'
+#!/usr/bin/env bash
+[ -n "$MD2PDF_PANDOC_ARGS_LOG" ] && printf '%s\n' "$@" > "$MD2PDF_PANDOC_ARGS_LOG"
+[ -n "$MD2PDF_PANDOC_INPUT_LOG" ] && cp "$1" "$MD2PDF_PANDOC_INPUT_LOG"
+saved_args=("$@")
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--css" ]; then
+    shift
+    [ -n "$MD2PDF_PANDOC_CSS_LOG" ] && [ -f "$1" ] && cp "$1" "$MD2PDF_PANDOC_CSS_LOG"
+  fi
+  shift
+done
+set -- "${saved_args[@]}"
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-o" ]; then
+    shift
+    touch "$1"
+    exit 0
+  fi
+  shift
+done
+exit 0
+SH
+
+  chmod +x "$TEST_TEMP_DIR/fake-bin/pandoc"
+  export PATH="$TEST_TEMP_DIR/fake-bin:$PATH"
+  export MD2PDF_PANDOC_ARGS_LOG="$TEST_TEMP_DIR/pandoc-args.txt"
+  export MD2PDF_PANDOC_INPUT_LOG="$TEST_TEMP_DIR/pandoc-input.md"
+  export MD2PDF_PANDOC_CSS_LOG="$TEST_TEMP_DIR/pandoc-css.txt"
+}
+
+write_doc() {
+  local path="$1"
+  shift
+  printf '%s\n' "$@" > "$path"
+}
+
+assert_arg_present() {
+  grep -qx -- "$1" "$MD2PDF_PANDOC_ARGS_LOG"
+}
+
+assert_arg_absent() {
+  ! grep -qx -- "$1" "$MD2PDF_PANDOC_ARGS_LOG"
+}
+
 setup() {
   TEST_TEMP_DIR="$(mktemp -d)"
   export MD2PDF_TOOL_HOME="$TEST_TEMP_DIR/tool_home"

--- a/tests/unicode_normalization.bats
+++ b/tests/unicode_normalization.bats
@@ -2,33 +2,6 @@
 
 load test_helper
 
-setup_fake_pandoc() {
-  mkdir -p "$TEST_TEMP_DIR/fake-bin"
-
-  cat > "$TEST_TEMP_DIR/fake-bin/xelatex" <<'SH'
-#!/usr/bin/env bash
-exit 0
-SH
-
-  cat > "$TEST_TEMP_DIR/fake-bin/pandoc" <<'SH'
-#!/usr/bin/env bash
-cp "$1" "$MD2PDF_PANDOC_INPUT_LOG"
-while [ "$#" -gt 0 ]; do
-  if [ "$1" = "-o" ]; then
-    shift
-    touch "$1"
-    exit 0
-  fi
-  shift
-done
-exit 0
-SH
-
-  chmod +x "$TEST_TEMP_DIR/fake-bin/pandoc" "$TEST_TEMP_DIR/fake-bin/xelatex"
-  export PATH="$TEST_TEMP_DIR/fake-bin:$PATH"
-  export MD2PDF_PANDOC_INPUT_LOG="$TEST_TEMP_DIR/pandoc-input.md"
-}
-
 @test "unicode normalization replaces checkmark emoji" {
   local input="$TEST_TEMP_DIR/input.md"
   local output="$TEST_TEMP_DIR/output.md"


### PR DESCRIPTION
Refactors pandoc markdown generation, document flags, render context assembly, option precedence, and unsupported-option warnings without changing CLI behavior. Consolidates repeated fake pandoc/TeX Bats setup into tests/test_helper.bash and removes duplicate helpers from focused test files. Verification passed with ruby -c bin/md2pdf, focused Bats suites, make test (179 tests), and git diff --check.